### PR TITLE
A temporary fix for .4ds files without materials such as storm1.4ds

### DIFF
--- a/components/4ds/osg.hpp
+++ b/components/4ds/osg.hpp
@@ -164,7 +164,10 @@ osg::ref_ptr<osg::Node> OSG4DSLoader::make4dsMeshLOD(DataFormat4DS::Lod *meshLOD
             static_cast<int>(materials.size() - 1),
             meshLOD->mFaceGroups[i].mMaterialID - 1));
 
-        faceGroup->setStateSet(materials[materialID]);
+// TODO: set default material when materialID = 0
+// or no materials are defined in .4ds file
+		if(materials.size() > 0)
+				faceGroup->setStateSet(materials[materialID]);
 
         group->addChild(faceGroup);
     }


### PR DESCRIPTION
Loading .4ds file without material such as _strom1.4ds_ caused **SEGFAULT** as the pool of materials was empty, yet material was set.

This bugfix should be replaced with setting default material when no material is available and `materialID = 0.`