### PR TITLE
Make viewer write out visually selected entity

### DIFF
--- a/apps/model_viewer/main.cpp
+++ b/apps/model_viewer/main.cpp
@@ -192,6 +192,8 @@ int main(int argc, char** argv)
         renderer.setCameraPositionRotation(cam[0],cam[1],cam[2],cam[3],cam[4],cam[5]);
     }
 
+    int lastSelectedEntity = -1;
+
 #define TEST_PHYSICS 0
 
 // TMP test:
@@ -218,6 +220,14 @@ int entCounter = 0;
         while (!renderer.done())    // main loop
         {
             double dt = 0.005;
+
+            int selectedId = renderer.getSelectedEntityId();
+
+            if (selectedId >= 0 && selectedId != lastSelectedEntity)
+            {
+                std::cout << "selected entity: " << entityManager.getEntityById(selectedId)->toString() << std::endl;
+                lastSelectedEntity = selectedId;
+            }
 
 // TMP test:
 #if TEST_PHYSICS

--- a/components/osg_utils.hpp
+++ b/components/osg_utils.hpp
@@ -306,6 +306,52 @@ std::string makeInfoString(osg::Node *n)
     return v.mInfo;
 }
 
+/**
+  User data that can be assigned to OSG objects.
+*/
+
+class UserData: public osg::Object
+{
+public:
+    UserData(): osg::Object() { strcpy(mLibraryName,"MFUtil"); strcpy(mClassName,"UserData"); };
+
+    virtual osg::Object *cloneType() const override                 { return 0;            };
+    virtual osg::Object *clone(const osg::CopyOp &) const override  { return 0;            };
+    virtual const char *libraryName() const override                { return mLibraryName; };
+    virtual const char *className() const override                  { return mClassName;   };
+
+protected:
+    char mLibraryName[255];
+    char mClassName[255];
+};
+
+class UserIntData: public UserData
+{
+public:
+    UserIntData(int value): UserData() { mValue = value; strcpy(mClassName,"UserIntData"); };
+
+    int mValue;
+};
+
+/**
+  Assigns user data to given node and all children;
+*/
+
+class AssignUserDataVisitor: public osg::NodeVisitor
+{
+public:
+    AssignUserDataVisitor(UserData *data): osg::NodeVisitor() { mData = data; };
+
+    virtual void apply(osg::Node &n) override
+    {
+        n.getOrCreateUserDataContainer()->addUserObject(mData);
+        MFUtil::traverse(this,n);
+    }
+
+protected:
+    osg::ref_ptr<UserData> mData;
+};
+
 }
 
 #endif

--- a/components/renderer/base_renderer.hpp
+++ b/components/renderer/base_renderer.hpp
@@ -20,6 +20,7 @@ public:
     virtual void setFreeCameraSpeed(double newSpeed)=0;
     bool done() { return mDone; };
     virtual bool exportScene(std::string fileName)=0;
+    virtual int getSelectedEntityId()=0;
 
     MFMath::Vec3 getCameraPosition() { double x,y,z,ya,pi,ro; getCameraPositionRotation(x,y,z,ya,pi,ro); return MFMath::Vec3(x,y,z); };
 

--- a/components/spatial_entity/spatial_entity_implementation.hpp
+++ b/components/spatial_entity/spatial_entity_implementation.hpp
@@ -215,7 +215,13 @@ void SpatialEntityImplementation::ready()
     MFLogger::ConsoleLogger::info("readying entity: " + toString(),SPATIAL_ENTITY_IMPLEMENTATION_MODULE_STR);
 
     if (mOSGNode)
+    {
         mOSGInitialTransform = mOSGNode->getMatrix();
+
+        osg::ref_ptr<MFUtil::UserIntData> intData = new MFUtil::UserIntData(mId);
+        MFUtil::AssignUserDataVisitor v(intData.get());
+        mOSGNode->accept(v);
+    }
 
     if (mBulletBody)
     {


### PR DESCRIPTION
as a part of preparations for upcoming entity debugging