### PR TITLE
Fix entity matching

### DIFF
--- a/apps/model_viewer/main.cpp
+++ b/apps/model_viewer/main.cpp
@@ -158,8 +158,9 @@ std::string getCollisionString(MFRender::Renderer *renderer, MFPhysics::MFPhysic
 
     MFMath::Vec3 pos = renderer->getCameraPosition();
     MFGame::Id entityID = world->pointCollision(pos);
+    MFGame::SpatialEntity *e = entityManager->getEntityById(entityID);
 
-    if (entityID != MFGame::NullId)
+    if (e)
         result += entityManager->getEntityById(entityID)->toString();
     else
         result += "none";

--- a/apps/model_viewer/main.cpp
+++ b/apps/model_viewer/main.cpp
@@ -28,6 +28,7 @@ static bool sSimulatePhysics = false;
 // TODO move this to Platform class
 #include <chrono>
 #include <thread>
+
 double timeGet()
 {
     static auto epoch = std::chrono::high_resolution_clock::now();
@@ -302,7 +303,6 @@ int main(int argc, char** argv)
 
     std::unique_ptr<MFGame::FreeCameraController> cameraController;
 
-
     if (model)
     {
         renderer.loadSingleModel(inputFile);
@@ -331,11 +331,13 @@ int main(int argc, char** argv)
         auto cameraEntity = entityFactory.createCameraEntity(renderer.getViewer()->getCamera());
         auto cameraPtr = entityManager.getEntityById(cameraEntity);
         auto pos = renderer.getCameraPosition();
+
         if (cameraPtr == nullptr)
         {
             MFLogger::ConsoleLogger::fatal("Camera was not initialized!");
             return 0;
         }
+
         cameraPtr->setPosition(pos);
         cameraController = std::make_unique<MFGame::RigidCameraController>(&renderer, &inputManager, cameraPtr);
     }

--- a/components/spatial_entity/factory.hpp
+++ b/components/spatial_entity/factory.hpp
@@ -237,6 +237,11 @@ protected:
         for (auto it = found.first; it != found.second; ++it)
             result.push_back(it->second);
 
+        found = mNameToBody.equal_range(mModelName);
+
+        for (auto it = found.first; it != found.second; ++it)
+            result.push_back(it->second);
+
         found = mNameToBody.equal_range(mModelName + "." + visualName);
 
         for (auto it = found.first; it != found.second; ++it)

--- a/components/spatial_entity/manager.hpp
+++ b/components/spatial_entity/manager.hpp
@@ -64,7 +64,11 @@ SpatialEntity *SpatialEntityManager::getEntityByIndex(unsigned int index)
 
 SpatialEntity *SpatialEntityManager::getEntityById(MFGame::Id id)
 {
+    if (id == MFGame::NullId)
+        return 0;
+
     auto entity = mEntities[id];
+
     if (!entity.get())
     {
         MFLogger::ConsoleLogger::warn("Can't retrieve invalid entity.", SPATIAL_ENTITY_MANAGER_MODULE_STR);


### PR DESCRIPTION
- [x] fix a bug where we were creating two entities instead of one
- [x] however, some physics-only entities have invisible debug representation (e.g. mise02-saliery, the front gate to saliery bar), though the rigid body is present and functioning