### PR TITLE
Refactor names

### DIFF
--- a/apps/game/main.cpp
+++ b/apps/game/main.cpp
@@ -8,7 +8,7 @@ class OpenMFEngine: public MFGame::Engine
 public:
     OpenMFEngine(MFGame::Engine::EngineSettings settings): MFGame::Engine(settings)
     {
-        mPlayerEntity = mSpatialEntityManager->getEntityById(mSpatialEntityFactory->createCapsuleEntity("tommy.4ds"));
+        mPlayerEntity = mSpatialEntityManager->getEntityById(mSpatialEntityFactory->createPawnEntity("tommy.4ds"));
         mPlayerController = new MFGame::PlayerController(mPlayerEntity,mRenderer,mInputManager,mPhysicsWorld);
 
         mSpatialEntityFactory->setDebugMode(false);

--- a/components/renderer/osg_renderer.hpp
+++ b/components/renderer/osg_renderer.hpp
@@ -25,6 +25,8 @@
 namespace MFRender
 {
 
+typedef MFFormat::LoaderCache<MFFormat::OSGLoader::OSGCached> OSGCache;
+
 class OSGRenderer: public Renderer
 {
 public:
@@ -52,8 +54,9 @@ public:
     void setUpInWindow(osgViewer::GraphicsWindow *window);
 
     void setRenderMask(osg::Node::NodeMask mask);
-    osg::Group *getRootNode()                      { return mRootNode.get(); };
-    osgViewer::Viewer *getViewer()                 { return mViewer.get();   };
+    osg::Group        *getRootNode()          { return mRootNode.get(); };
+    osgViewer::Viewer *getViewer()            { return mViewer.get();   };
+    OSGCache          *getLoaderCache()       { return &mLoaderCache;   };
 
     virtual void cameraFace(MFMath::Vec3 position) override;
 
@@ -61,7 +64,7 @@ protected:
     osg::ref_ptr<osgViewer::Viewer> mViewer;    
     osg::ref_ptr<osg::Group> mRootNode;            ///< root node of the whole scene being rendered
     MFFile::FileSystem *mFileSystem;
-    MFFormat::LoaderCache<MFFormat::OSGLoader::OSGCached> mLoaderCache;
+    OSGCache mLoaderCache;
 
     void optimize();
 

--- a/components/spatial_entity/factory.cpp
+++ b/components/spatial_entity/factory.cpp
@@ -93,22 +93,28 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createPawnEntity(std::string mod
     }
     else
     {
-        std::ifstream file4DS;
-        MFFormat::OSG4DSLoader l4ds;
+        auto cache = mRenderer->getLoaderCache();
+        auto model = (osg::Node *)cache->getObject(modelName).get();
 
-        // TODO: use loader cache
+        if (!model) {
+            std::ifstream file4DS;
+            MFFormat::OSG4DSLoader l4ds;
+            l4ds.setLoaderCache(cache);
 
-        if (!mFileSystem->open(file4DS,"models/" + modelName))
-        {
-            MFLogger::Logger::warn("Couldn't not open 4ds file: " + modelName + ".",SPATIAL_ENTITY_FACTORY_MODULE_STR);
+            if (!mFileSystem->open(file4DS, "models/" + modelName)) {
+                MFLogger::Logger::warn("Couldn't not open 4ds file: " + modelName + ".", SPATIAL_ENTITY_FACTORY_MODULE_STR);
+            }
+            else {
+                model = l4ds.load(file4DS, modelName);
+                file4DS.close();
+                model->setName(modelName);
+            }
         }
-        else
-        {
-            visualTransform->addChild(l4ds.load(file4DS));
 
-            // TMP: shift a little down
-            visualTransform->setMatrix(osg::Matrixd::translate(osg::Vec3(0,0,-1)));
-        }
+        visualTransform->addChild(model);
+
+        // TMP: shift a little down
+        visualTransform->setMatrix(osg::Matrixd::translate(osg::Vec3(0, 0, -1)));
     }
 
     mRenderer->getRootNode()->addChild(visualTransform);

--- a/components/spatial_entity/factory.cpp
+++ b/components/spatial_entity/factory.cpp
@@ -69,7 +69,7 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createEntity(
     return newEntity->getId();
 }
 
-MFGame::SpatialEntity::Id SpatialEntityFactory::createCapsuleEntity(std::string modelName)
+MFGame::SpatialEntity::Id SpatialEntityFactory::createPawnEntity(std::string modelName)
 {
     MFUtil::FullRigidBody body;
 
@@ -113,7 +113,7 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createCapsuleEntity(std::string 
 
     mRenderer->getRootNode()->addChild(visualTransform);
 
-    return createEntity(visualTransform.get(), body.mBody, body.mMotionState, "capsule", SpatialEntity::RIGID_PLAYER);
+    return createEntity(visualTransform.get(), body.mBody, body.mMotionState, "capsule", SpatialEntity::RIGID_PAWN);
 }
 
 MFGame::SpatialEntity::Id SpatialEntityFactory::createCameraEntity()
@@ -135,7 +135,7 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createCameraEntity()
     osg::ref_ptr<osg::MatrixTransform> visualTransform = new osg::MatrixTransform();
     mRenderer->getRootNode()->addChild(visualTransform);
 
-    return createEntity(visualTransform.get(), body.mBody, body.mMotionState, "camera", SpatialEntity::RIGID_PLAYER);
+    return createEntity(visualTransform.get(), body.mBody, body.mMotionState, "camera", SpatialEntity::RIGID_PAWN);
 }
 
 MFGame::SpatialEntity::Id SpatialEntityFactory::createTestShapeEntity(btCollisionShape *colShape, osg::ShapeDrawable *visualNode)

--- a/components/spatial_entity/factory.hpp
+++ b/components/spatial_entity/factory.hpp
@@ -29,7 +29,7 @@ public:
 
     MFGame::SpatialEntity::Id createTestBallEntity();
     MFGame::SpatialEntity::Id createTestBoxEntity();
-    MFGame::SpatialEntity::Id createCapsuleEntity(std::string modelName="");
+    MFGame::SpatialEntity::Id createPawnEntity(std::string modelName="");
     MFGame::SpatialEntity::Id createCameraEntity();
     MFGame::SpatialEntity::Id createTestShapeEntity(btCollisionShape *colShape, osg::ShapeDrawable *visualNode);
 

--- a/components/spatial_entity/spatial_entity.hpp
+++ b/components/spatial_entity/spatial_entity.hpp
@@ -23,7 +23,7 @@ public:
         STATIC,            ///< The entity cannot move.
         KINEMATIC,         ///< The entity can move, but doesn't react to collisions.
         RIGID,             ///< The entity can move and react to collisions as a rigid body.
-        RIGID_PLAYER       ///< Same as RIGID, but cannot rotate (e.g. player capsule collision).
+        RIGID_PAWN       ///< Same as RIGID, but cannot rotate (e.g. player capsule collision).
     } PhysicsBehavior;
 
     typedef uint32_t Id;

--- a/components/spatial_entity/spatial_entity_implementation.cpp
+++ b/components/spatial_entity/spatial_entity_implementation.cpp
@@ -26,7 +26,7 @@ void SpatialEntityImplementation::setPhysicsBehavior(SpatialEntity::PhysicsBehav
         case SpatialEntity::RIGID:
             break;
 
-        case SpatialEntity::RIGID_PLAYER:
+        case SpatialEntity::RIGID_PAWN:
             mBulletBody->setAngularFactor(0);
             break;
 


### PR DESCRIPTION
Rename RIGID_PLAYER to RIGID_PAWN as the same physics behavior applies to it.

Also renames createCapsuleEntity into createPawnEntity, since the created entity consists of a model + capsule collision.