### PR TITLE
Mission loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ file(GLOB_RECURSE GAME_COMPONENT_SOURCES
     "components/renderer/*.cpp"
     "components/spatial_entity/*.cpp"
     "components/engine/*.cpp"
+    "components/mission/*.cpp"
     "components/utils/osg.cpp"
     "components/utils/bullet.cpp"
     "components/base_loader.cpp"

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ If you'd like to join us and contribute, see [development.md](https://github.com
 
 ## Screenshots    
 ![](https://github.com/OpenMafia/openmf/blob/master/resources/screens.jpg?raw=true)
+![](https://i.imgur.com/41q3JQe.gif)

--- a/apps/game/main.cpp
+++ b/apps/game/main.cpp
@@ -95,6 +95,9 @@ int main(int argc, char** argv)
     settings.mVsync = arguments.count("vsync") > 1;
     MafiaEngine engine(settings);
 
+    ((MFRender::OSGRenderer *) engine.getRenderer())->setRenderMask(3);
+    engine.getSpatialEntityFactory()->setDebugMode(true);
+
     switch (scenario)
     {
         case 1:

--- a/apps/game/main.cpp
+++ b/apps/game/main.cpp
@@ -64,18 +64,16 @@ public:
 
     void useDefaultPlayer()
     {
-        for (auto const& pair : *mSpatialEntityManager->getEntities()) {
-            if (pair.second->getName() == "player start") {
-                auto pos = pair.second->getPosition();
-                auto spat = (MFGame::SpatialEntityImpl *)pair.second.get();
-                setPlayerPosition(MFMath::Vec3(pos.x, pos.y, pos.z + 1)); // +1 due to player being moved in the middle of the ground
+        auto spawnEntity = mSpatialEntityManager->getEntityByName("player start");
 
-                mRenderer->getRootNode()->removeChild(mPlayerEntity->getVisualNode());
+        if (spawnEntity) {
+            auto pos = spawnEntity->getPosition();
+            auto spat = (MFGame::SpatialEntityImpl *)spawnEntity;
+            setPlayerPosition(MFMath::Vec3(pos.x, pos.y, pos.z + 1)); // +1 due to player being moved in the middle of the ground
 
-                mPlayerEntity->setVisualNode(spat->getVisualNode());
-                
-                return;
-            }
+            mRenderer->getRootNode()->removeChild(mPlayerEntity->getVisualNode());
+
+            mPlayerEntity->setVisualNode(spat->getVisualNode());
         }
     };
 

--- a/apps/game/main.cpp
+++ b/apps/game/main.cpp
@@ -95,9 +95,6 @@ int main(int argc, char** argv)
     settings.mVsync = arguments.count("vsync") > 1;
     MafiaEngine engine(settings);
 
-    ((MFRender::OSGRenderer *) engine.getRenderer())->setRenderMask(3);
-    engine.getSpatialEntityFactory()->setDebugMode(true);
-
     switch (scenario)
     {
         case 1:

--- a/apps/viewer/main.cpp
+++ b/apps/viewer/main.cpp
@@ -46,10 +46,11 @@ public:
 
         if (keyCode == OMF_SCANCODE_SPACE)   // SPACE
         {
+            auto mission = mEngine->getMissionManager()->getCurrentMission();
+            if (!mission) return;
+
             MFGame::SpatialEntity *e = mEngine->getSpatialEntityManager()->getEntityById(
-                mCounter % 2 == 0 ?
-                    mEngine->getSpatialEntityFactory()->createTestBallEntity() :
-                    mEngine->getSpatialEntityFactory()->createTestBoxEntity());
+                mEngine->getSpatialEntityFactory()->createPropEntity("bedna02.4ds"));
 
             MFMath::Vec3 f,r,u;
             mEngine->getRenderer()->getCameraVectors(f,r,u);

--- a/apps/viewer/main.cpp
+++ b/apps/viewer/main.cpp
@@ -221,6 +221,7 @@ int main(int argc, char** argv)
         MFLogger::Logger::setVerbosityFlags(0xffff);
         MFLogger::Logger::addFilter(VIEWER_MODULE_STR);
         MFLogger::Logger::addFilter(OSGRENDERER_MODULE_STR);
+        MFLogger::Logger::addFilter(MISSION_MANAGER_MODULE_STR);
         MFLogger::Logger::setFilterMode(false);
     }
 

--- a/apps/viewer/main.cpp
+++ b/apps/viewer/main.cpp
@@ -151,7 +151,6 @@ int main(int argc, char** argv)
     options.add_options()
         ("h,help","Display help and exit.")
         ("i,input","Specify input, mission name by default.",cxxopts::value<std::string>())
-        ("4,4ds","Load single 4ds model instead of mission.")
         ("f,fov","Specify camera field of view in degrees.",cxxopts::value<int>())
         ("s,camera-speed","Set camera speed (default is " + std::to_string(DEFAULT_CAMERA_SPEED) +  ").",cxxopts::value<double>())
         ("c,camera-info","Write camera position and rotation in console.")
@@ -236,10 +235,7 @@ int main(int argc, char** argv)
         engine.getSpatialEntityFactory()->setDebugMode(true);
     }
 
-    if (arguments.count("4") == 0)
-        engine.loadMission(inputFile);
-    else
-        engine.loadSingleModel(inputFile);
+    engine.loadMission(inputFile);
 
     if (arguments.count("V") > 0)
         engine.getRenderer()->setViewDistance(arguments["V"].as<int>());

--- a/components/4ds/osg_4ds.cpp
+++ b/components/4ds/osg_4ds.cpp
@@ -500,7 +500,7 @@ osg::ref_ptr<osg::StateSet> OSG4DSLoader::make4dsMaterial(MFFormat::DataFormat4D
     return stateSet;
 }
 
-osg::ref_ptr<osg::Node> OSG4DSLoader::load(std::ifstream &srcFile, std::string fileName)
+osg::ref_ptr<osg::Node> OSG4DSLoader::load(MFFormat::DataFormat4DS *format, std::string fileName)
 {
     if (fileName.length() > 0)
     {
@@ -512,65 +512,60 @@ osg::ref_ptr<osg::Node> OSG4DSLoader::load(std::ifstream &srcFile, std::string f
 
     std::string logStr = "loading model";
 
-    MFFormat::DataFormat4DS format;
-
     osg::ref_ptr<osg::MatrixTransform> group = new osg::MatrixTransform();
     group->setName("4DS model");
 
-    if (format.load(srcFile))
-    {
-        auto model = format.getModel();
+    auto model = format->getModel();
         
-        logStr += ", meshes: " + std::to_string(model.mMeshCount);
-        logStr += ", materials: " + std::to_string(model.mMaterialCount);
+    logStr += ", meshes: " + std::to_string(model.mMeshCount);
+    logStr += ", materials: " + std::to_string(model.mMaterialCount);
 
-        MFLogger::Logger::info(logStr,OSG4DS_MODULE_STR);
+    MFLogger::Logger::info(logStr,OSG4DS_MODULE_STR);
 
-        MaterialList materials;
+    MaterialList materials;
 
-        for (int i = 0; i < model.mMaterialCount; ++i)  // load materials
-        {
-            MFLogger::Logger::info("  Loading material " + std::to_string(i) + ".",OSG4DS_MODULE_STR);
-            materials.push_back(make4dsMaterial(&(model.mMaterials[i])));
-        }
+    for (int i = 0; i < model.mMaterialCount; ++i)  // load materials
+    {
+        MFLogger::Logger::info("  Loading material " + std::to_string(i) + ".",OSG4DS_MODULE_STR);
+        materials.push_back(make4dsMaterial(&(model.mMaterials[i])));
+    }
 
-        std::vector<osg::ref_ptr<osg::MatrixTransform>> meshes;
+    std::vector<osg::ref_ptr<osg::MatrixTransform>> meshes;
 
-        for (int i = 0; i < model.mMeshCount; ++i)      // load meshes
-        {
-            osg::ref_ptr<osg::MatrixTransform> transform = new osg::MatrixTransform();
-            std::string meshName = MFUtil::charArrayToStr(model.mMeshes[i].mMeshName,model.mMeshes[i].mMeshNameLength);
-            transform->setName(meshName);  // don't mess with this name, it's needed to link with collisions etc.
+    for (int i = 0; i < model.mMeshCount; ++i)      // load meshes
+    {
+        osg::ref_ptr<osg::MatrixTransform> transform = new osg::MatrixTransform();
+        std::string meshName = MFUtil::charArrayToStr(model.mMeshes[i].mMeshName,model.mMeshes[i].mMeshNameLength);
+        transform->setName(meshName);  // don't mess with this name, it's needed to link with collisions etc.
 
-            transform->getOrCreateUserDataContainer()->addDescription("4ds mesh");    // mark the node as a 4DS mesh
+        transform->getOrCreateUserDataContainer()->addDescription("4ds mesh");    // mark the node as a 4DS mesh
 
-            osg::Matrixd mat;
+        osg::Matrixd mat;
 
-            MFMath::Vec3 p, s;
-            MFMath::Quat r;
+        MFMath::Vec3 p, s;
+        MFMath::Quat r;
 
-            p = model.mMeshes[i].mPos;
-            s = model.mMeshes[i].mScale;
-            r = model.mMeshes[i].mRot;
+        p = model.mMeshes[i].mPos;
+        s = model.mMeshes[i].mScale;
+        r = model.mMeshes[i].mRot;
 
-            transform->setMatrix(makeTransformMatrix(p,s,r));
-            transform->addChild(make4dsMesh(&(model.mMeshes[i]),materials));
+        transform->setMatrix(makeTransformMatrix(p,s,r));
+        transform->addChild(make4dsMesh(&(model.mMeshes[i]),materials));
                 
-            meshes.push_back(transform);
+        meshes.push_back(transform);
 
-            if (mNodeMap)
-                mNodeMap->insert(mNodeMap->begin(),std::pair<std::string,osg::ref_ptr<osg::Group>>(meshName,transform));
-        }
+        if (mNodeMap)
+            mNodeMap->insert(mNodeMap->begin(),std::pair<std::string,osg::ref_ptr<osg::Group>>(meshName,transform));
+    }
 
-        for (int i = 0; i < model.mMeshCount; ++i)     // parent meshes
-        {
-            unsigned int parentID = model.mMeshes[i].mParentID;
+    for (int i = 0; i < model.mMeshCount; ++i)     // parent meshes
+    {
+        unsigned int parentID = model.mMeshes[i].mParentID;
 
-            if (parentID == 0)
-                group->addChild(meshes[i]);
-            else
-                meshes[parentID - 1]->addChild(meshes[i]);
-        }
+        if (parentID == 0)
+            group->addChild(meshes[i]);
+        else
+            meshes[parentID - 1]->addChild(meshes[i]);
     }
 
     if (fileName.length() > 0)

--- a/components/4ds/osg_4ds.cpp
+++ b/components/4ds/osg_4ds.cpp
@@ -36,7 +36,7 @@ protected:
     unsigned int mFramePeriod;
 };
 
-std::vector<std::string> OSG4DSLoader::makeAnimationNames(std::string baseFileName, unsigned int frames)
+std::vector<std::string> OSGModelLoader::makeAnimationNames(std::string baseFileName, unsigned int frames)
 {
     // FIXME: make this nicer 
 
@@ -70,7 +70,7 @@ std::vector<std::string> OSG4DSLoader::makeAnimationNames(std::string baseFileNa
     return result;
 }
 
-osg::ref_ptr<osg::Texture2D> OSG4DSLoader::loadTexture(std::string fileName, std::string fileNameAlpha, bool colorKey)
+osg::ref_ptr<osg::Texture2D> OSGModelLoader::loadTexture(std::string fileName, std::string fileNameAlpha, bool colorKey)
 {
     std::string textureIdentifier = fileName + ";" + fileNameAlpha + ";" + (colorKey ? "1" : "0");
 
@@ -166,7 +166,7 @@ osg::ref_ptr<osg::Texture2D> OSG4DSLoader::loadTexture(std::string fileName, std
     return tex;
 }
 
-osg::ref_ptr<osg::Node> OSG4DSLoader::make4dsFaceGroup(
+osg::ref_ptr<osg::Node> OSGModelLoader::make4dsFaceGroup(
         osg::Vec3Array *vertices,
         osg::Vec3Array *normals,
         osg::Vec2Array *uvs,
@@ -211,7 +211,7 @@ osg::ref_ptr<osg::Node> OSG4DSLoader::make4dsFaceGroup(
     return geode;
 }
 
-osg::ref_ptr<osg::Node> OSG4DSLoader::make4dsMesh(DataFormat4DS::Mesh *mesh, MaterialList &materials)
+osg::ref_ptr<osg::Node> OSGModelLoader::make4dsMesh(DataFormat4DS::Mesh *mesh, MaterialList &materials)
 {
     if (mesh->mMeshType != MFFormat::DataFormat4DS::MESHTYPE_STANDARD)
     {
@@ -286,7 +286,7 @@ osg::ref_ptr<osg::Node> OSG4DSLoader::make4dsMesh(DataFormat4DS::Mesh *mesh, Mat
     return nodeLOD; 
 }
 
-osg::ref_ptr<osg::Node> OSG4DSLoader::make4dsMeshLOD(
+osg::ref_ptr<osg::Node> OSGModelLoader::make4dsMeshLOD(
     DataFormat4DS::Lod *meshLOD,
     MaterialList &materials,
     bool isBillboard,
@@ -343,7 +343,7 @@ osg::ref_ptr<osg::Node> OSG4DSLoader::make4dsMeshLOD(
     return group;
 }
 
-osg::ref_ptr<osg::StateSet> OSG4DSLoader::make4dsMaterial(MFFormat::DataFormat4DS::Material *material)
+osg::ref_ptr<osg::StateSet> OSGModelLoader::make4dsMaterial(MFFormat::DataFormat4DS::Material *material)
 {
     osg::ref_ptr<osg::StateSet> stateSet = new osg::StateSet;
 
@@ -500,7 +500,7 @@ osg::ref_ptr<osg::StateSet> OSG4DSLoader::make4dsMaterial(MFFormat::DataFormat4D
     return stateSet;
 }
 
-osg::ref_ptr<osg::Node> OSG4DSLoader::load(MFFormat::DataFormat4DS *format, std::string fileName)
+osg::ref_ptr<osg::Node> OSGModelLoader::load(MFFormat::DataFormat4DS *format, std::string fileName)
 {
     if (fileName.length() > 0)
     {

--- a/components/4ds/osg_4ds.hpp
+++ b/components/4ds/osg_4ds.hpp
@@ -33,7 +33,7 @@
 namespace MFFormat
 {
 
-class OSG4DSLoader: public OSGLoader
+class OSGModelLoader: public OSGLoader
 {
 public:
     osg::ref_ptr<osg::Node> load(MFFormat::DataFormat4DS *format, std::string fileName="");

--- a/components/4ds/osg_4ds.hpp
+++ b/components/4ds/osg_4ds.hpp
@@ -36,7 +36,7 @@ namespace MFFormat
 class OSG4DSLoader: public OSGLoader
 {
 public:
-    virtual osg::ref_ptr<osg::Node> load(std::ifstream &srcFile, std::string fileName="") override;
+    osg::ref_ptr<osg::Node> load(MFFormat::DataFormat4DS *format, std::string fileName="");
 
 protected:
     typedef std::vector<osg::ref_ptr<osg::StateSet>> MaterialList;

--- a/components/4ds/parser_4ds.hpp
+++ b/components/4ds/parser_4ds.hpp
@@ -2,6 +2,7 @@
 #define FORMAT_PARSERS_4DS_H
 
 #include <base_parser.hpp>
+#include <loader_cache.hpp>
 #include <cstring>
 #include <utils/math.hpp>
 

--- a/components/base_loader.cpp
+++ b/components/base_loader.cpp
@@ -92,7 +92,7 @@ osg::ref_ptr<osg::Node> OSGLoader::loadFile(std::string fileName)
 
     if (f.is_open())
     {
-        n = load(f,fileName);
+        //n = load(f,fileName);
         f.close();
     }
     else

--- a/components/base_loader.hpp
+++ b/components/base_loader.hpp
@@ -7,11 +7,13 @@
 #include <vfs/vfs.hpp>
 #include <loader_cache.hpp>
 #include <utils/math.hpp>
-
 #define OSGLOADER_MODULE_STR "OSG loader"
 
 namespace MFFormat
 {
+
+    class DataFormat4DS;
+    typedef MFFormat::LoaderCache<MFFormat::DataFormat4DS*> ModelCache;
 
 class OSGLoader
 {
@@ -24,6 +26,7 @@ public:
     osg::ref_ptr<osg::Node> loadFile(std::string fileName);                                   // overloading load() didn't work somehow - why?
     void setBaseDir(std::string baseDir);
     void setLoaderCache(LoaderCache<OSGCached> *cache) { mLoaderCache = cache; };
+    void setModelCache(MFFormat::ModelCache *cache) { mModelCache = cache; }
 
     osg::Vec3f toOSG(MFMath::Vec3 v);
     osg::Quat toOSG(MFMath::Quat q);
@@ -47,6 +50,7 @@ protected:
     osg::Matrixd mMafiaToOSGMatrixInvert;
 
     LoaderCache<OSGCached> *mLoaderCache;   ///< Derived classes should make use of the cache with getFromChache/storeToCache.
+    MFFormat::ModelCache  *mModelCache;
 
     osg::ref_ptr<osg::Referenced> getFromCache(std::string identifier);
     void storeToCache(std::string identifier,OSGCached obj);

--- a/components/base_loader.hpp
+++ b/components/base_loader.hpp
@@ -7,6 +7,9 @@
 #include <vfs/vfs.hpp>
 #include <loader_cache.hpp>
 #include <utils/math.hpp>
+
+namespace MFGame { class ObjectFactory; }
+
 #define OSGLOADER_MODULE_STR "OSG loader"
 
 namespace MFFormat
@@ -26,7 +29,7 @@ public:
     osg::ref_ptr<osg::Node> loadFile(std::string fileName);                                   // overloading load() didn't work somehow - why?
     void setBaseDir(std::string baseDir);
     void setLoaderCache(LoaderCache<OSGCached> *cache) { mLoaderCache = cache; };
-    void setModelCache(MFFormat::ModelCache *cache) { mModelCache = cache; }
+    void setObjectFactory(MFGame::ObjectFactory *factory) { mObjectFactory = factory; }
 
     osg::Vec3f toOSG(MFMath::Vec3 v);
     osg::Quat toOSG(MFMath::Quat q);
@@ -50,7 +53,7 @@ protected:
     osg::Matrixd mMafiaToOSGMatrixInvert;
 
     LoaderCache<OSGCached> *mLoaderCache;   ///< Derived classes should make use of the cache with getFromChache/storeToCache.
-    MFFormat::ModelCache  *mModelCache;
+    MFGame::ObjectFactory *mObjectFactory;
 
     osg::ref_ptr<osg::Referenced> getFromCache(std::string identifier);
     void storeToCache(std::string identifier,OSGCached obj);

--- a/components/base_loader.hpp
+++ b/components/base_loader.hpp
@@ -15,9 +15,6 @@ namespace MFGame { class ObjectFactory; }
 namespace MFFormat
 {
 
-    class DataFormat4DS;
-    typedef MFFormat::LoaderCache<MFFormat::DataFormat4DS*> ModelCache;
-
 class OSGLoader
 {
 public:

--- a/components/base_loader.hpp
+++ b/components/base_loader.hpp
@@ -21,14 +21,6 @@ public:
 
     OSGLoader();
 
-    /**
-        Load given object into OSG node.
-
-        @param srcFile    file stream to load the object from
-        @param fileName   optional file name that serves to reuse already loaded objects from cache
-    */
-    virtual osg::ref_ptr<osg::Node> load(std::ifstream &srcFile,std::string fileName="")=0;
-
     osg::ref_ptr<osg::Node> loadFile(std::string fileName);                                   // overloading load() didn't work somehow - why?
     void setBaseDir(std::string baseDir);
     void setLoaderCache(LoaderCache<OSGCached> *cache) { mLoaderCache = cache; };

--- a/components/cache_bin/osg_cachebin.cpp
+++ b/components/cache_bin/osg_cachebin.cpp
@@ -3,61 +3,58 @@
 namespace MFFormat
 {
 
-osg::ref_ptr<osg::Node> OSGCacheBinLoader::load(std::ifstream &srcFile, std::string fileName)
+osg::ref_ptr<osg::Node> OSGCacheBinLoader::load(MFFormat::DataFormatCacheBIN *format, std::string fileName)
 {
     osg::ref_ptr<osg::Group> group = new osg::Group();
     group->setName("cache.bin");
     MFLogger::Logger::info("loading cache.bin", OSGCACHEBIN_MODULE_STR);
-    MFFormat::DataFormatCacheBIN parser;
     MFFormat::OSG4DSLoader loader4DS;
-    bool success = parser.load(srcFile);
-
-    if (success)
+    
+    for (auto object : format->getObjects())
     {
-        for (auto object : parser.getObjects())
-        {
-            MFLogger::Logger::info("Loading object " + object.mObjectName + ".", OSGCACHEBIN_MODULE_STR);
+        MFLogger::Logger::info("Loading object " + object.mObjectName + ".", OSGCACHEBIN_MODULE_STR);
         
-            osg::ref_ptr<osg::Group> objectGroup = new osg::Group();
-            group->setName("object group");
+        osg::ref_ptr<osg::Group> objectGroup = new osg::Group();
+        group->setName("object group");
 
-            for (auto instance : object.mInstances)
+        for (auto instance : object.mInstances)
+        {
+            osg::ref_ptr<osg::Node> objectNode = (osg::Node *) getFromCache(instance.mModelName).get();
+
+            if (!objectNode)
             {
-                osg::ref_ptr<osg::Node> objectNode = (osg::Node *) getFromCache(instance.mModelName).get();
-
-                if (!objectNode)
-                {
-                    MFLogger::Logger::info("Loading model " + instance.mModelName + ". (" + instance.mPos.str() + ")",OSGCACHEBIN_MODULE_STR);
-                    std::ifstream f;
+                MFLogger::Logger::info("Loading model " + instance.mModelName + ". (" + instance.mPos.str() + ")",OSGCACHEBIN_MODULE_STR);
+                std::ifstream f;
                     
-                    if (!mFileSystem->open(f,"MODELS/" + instance.mModelName))
-                    {
-                        MFLogger::Logger::warn("Could not load model " + instance.mModelName + ".", OSGCACHEBIN_MODULE_STR);
-                    }
-                    else
-                    {
-                        objectNode = loader4DS.load(f, instance.mModelName);
-                        storeToCache(instance.mModelName, objectNode);
-                        f.close();
-                    }
-                }
-                
-                if (objectNode.get())
+                if (!mFileSystem->open(f,"MODELS/" + instance.mModelName))
                 {
-                    osg::ref_ptr<osg::MatrixTransform> objectTransform = new osg::MatrixTransform();
-                    objectTransform->setName("object transform");
-
-                    osg::Matrixd m = makeTransformMatrix(instance.mPos, instance.mScale, instance.mRot);
-                    objectTransform->setMatrix(m);
-
-                    objectTransform->addChild(objectNode);
-                    objectGroup->addChild(objectTransform);
+                    MFLogger::Logger::warn("Could not load model " + instance.mModelName + ".", OSGCACHEBIN_MODULE_STR);
                 }
-            }   // for instances
+                else
+                {
+                    MFFormat::DataFormat4DS model; model.load(f);
+                    objectNode = loader4DS.load(&model, instance.mModelName);
+                    storeToCache(instance.mModelName, objectNode);
+                    f.close();
+                }
+            }
+                
+            if (objectNode.get())
+            {
+                osg::ref_ptr<osg::MatrixTransform> objectTransform = new osg::MatrixTransform();
+                objectTransform->setName("object transform");
 
-            group->addChild(objectGroup);
-        }       // for objects
-    }
+                osg::Matrixd m = makeTransformMatrix(instance.mPos, instance.mScale, instance.mRot);
+                objectTransform->setMatrix(m);
+
+                objectTransform->addChild(objectNode);
+                objectGroup->addChild(objectTransform);
+            }
+        }   // for instances
+
+        group->addChild(objectGroup);
+    }       // for objects
+    
 
     return group;
 }

--- a/components/cache_bin/osg_cachebin.cpp
+++ b/components/cache_bin/osg_cachebin.cpp
@@ -1,4 +1,5 @@
 #include <cache_bin/osg_cachebin.hpp>
+#include "spatial_entity/factory.hpp"
 
 namespace MFFormat
 {
@@ -8,7 +9,7 @@ osg::ref_ptr<osg::Node> OSGCachedCityLoader::load(MFFormat::DataFormatCacheBIN *
     osg::ref_ptr<osg::Group> group = new osg::Group();
     group->setName("cache.bin");
     MFLogger::Logger::info("loading cache.bin", OSGCACHEBIN_MODULE_STR);
-    MFFormat::OSG4DSLoader loader4DS;
+    MFFormat::OSGModelLoader loader4DS;
     
     for (auto object : format->getObjects())
     {
@@ -19,42 +20,7 @@ osg::ref_ptr<osg::Node> OSGCachedCityLoader::load(MFFormat::DataFormatCacheBIN *
 
         for (auto instance : object.mInstances)
         {
-            osg::ref_ptr<osg::Node> objectNode = (osg::Node *) getFromCache(instance.mModelName).get();
-
-            if (!objectNode)
-            {
-                MFLogger::Logger::info("Loading model " + instance.mModelName + ". (" + instance.mPos.str() + ")",OSGCACHEBIN_MODULE_STR);
-                
-                MFFormat::DataFormat4DS *model = nullptr;
-
-                if (mModelCache) {
-                    model = mModelCache->getObject(instance.mModelName);
-
-                    loadModel:
-                    if (!model) {
-                        model = new MFFormat::DataFormat4DS();
-                        std::ifstream f;
-
-                        if (!mFileSystem->open(f, "MODELS/" + instance.mModelName))
-                        {
-                            MFLogger::Logger::warn("Could not load model " + instance.mModelName + ".", OSGCACHEBIN_MODULE_STR);
-                        }
-                        else
-                        {
-                            model->load(f);
-                            objectNode = loader4DS.load(model, instance.mModelName);
-                            storeToCache(instance.mModelName, objectNode);
-                            f.close();
-                        }
-
-                        if (mModelCache)
-                            mModelCache->storeObject(instance.mModelName, model);
-                    }
-                }
-                else {
-                    goto loadModel;
-                }
-            }
+            osg::ref_ptr<osg::Node> objectNode = mObjectFactory->loadModel(instance.mModelName);
                 
             if (objectNode.get())
             {

--- a/components/cache_bin/osg_cachebin.hpp
+++ b/components/cache_bin/osg_cachebin.hpp
@@ -10,7 +10,7 @@
 namespace MFFormat
 {
 
-class OSGCacheBinLoader : public OSGLoader
+class OSGCachedCityLoader : public OSGLoader
 {
 public:
     osg::ref_ptr<osg::Node> load(MFFormat::DataFormatCacheBIN *format, std::string fileName = "");

--- a/components/cache_bin/osg_cachebin.hpp
+++ b/components/cache_bin/osg_cachebin.hpp
@@ -13,7 +13,7 @@ namespace MFFormat
 class OSGCacheBinLoader : public OSGLoader
 {
 public:
-    osg::ref_ptr<osg::Node> load(std::ifstream &srcFile, std::string fileName = "");
+    osg::ref_ptr<osg::Node> load(MFFormat::DataFormatCacheBIN *format, std::string fileName = "");
 };
 
 }

--- a/components/engine/engine.cpp
+++ b/components/engine/engine.cpp
@@ -46,8 +46,7 @@ Engine::Engine(EngineSettings settings)
     mInputManager = new MFInput::InputManagerImpl();
     mSpatialEntityManager = new SpatialEntityManager();
     mSpatialEntityFactory = new SpatialEntityFactory(mRenderer,mPhysicsWorld,mSpatialEntityManager);
-    mSpatialEntityFactory->setModelCache(&mModelCache);
-
+    
     mInputManager->initWindow(
         mEngineSettings.mInitWindowWidth,
         mEngineSettings.mInitWindowHeight,
@@ -121,8 +120,6 @@ bool Engine::loadMission(std::string missionName)
 
     if (mEngineSettings.mLoadTreeKlz)
         mPhysicsWorld->loadMission(missionName);
-
-    mSpatialEntityFactory->createMissionEntities();
 
     return true;   // TODO: perform some actual checks
 }

--- a/components/engine/engine.cpp
+++ b/components/engine/engine.cpp
@@ -118,9 +118,6 @@ bool Engine::loadMission(std::string missionName)
 { 
     mMissionManager->loadMission(missionName);
 
-    if (mEngineSettings.mLoadTreeKlz)
-        mPhysicsWorld->loadMission(missionName);
-
     return true;   // TODO: perform some actual checks
 }
 

--- a/components/engine/engine.cpp
+++ b/components/engine/engine.cpp
@@ -46,6 +46,7 @@ Engine::Engine(EngineSettings settings)
     mInputManager = new MFInput::InputManagerImpl();
     mSpatialEntityManager = new SpatialEntityManager();
     mSpatialEntityFactory = new SpatialEntityFactory(mRenderer,mPhysicsWorld,mSpatialEntityManager);
+    mSpatialEntityFactory->setModelCache(&mModelCache);
 
     mInputManager->initWindow(
         mEngineSettings.mInitWindowWidth,

--- a/components/engine/engine.cpp
+++ b/components/engine/engine.cpp
@@ -58,6 +58,8 @@ Engine::Engine(EngineSettings settings)
     mInputManager->addWindowResizeCallback(wrcb);
 
     mRenderer->setUpInWindow(mInputManager->getWindow());
+    
+    mMissionManager = new MFGame::MissionManager(this);
 }
 
 std::string Engine::getCameraInfoString()
@@ -114,7 +116,7 @@ bool Engine::exportScene(std::string outputFileName)
 
 bool Engine::loadMission(std::string missionName)
 { 
-    mRenderer->loadMission(missionName,mEngineSettings.mLoad4ds,mEngineSettings.mLoadScene2Bin,mEngineSettings.mLoadCacheBin);
+    mMissionManager->loadMission(missionName);
 
     if (mEngineSettings.mLoadTreeKlz)
         mPhysicsWorld->loadMission(missionName);
@@ -123,12 +125,6 @@ bool Engine::loadMission(std::string missionName)
 
     return true;   // TODO: perform some actual checks
 }
- 
-bool Engine::loadSingleModel(std::string modelName)
-{
-    mRenderer->loadSingleModel(modelName);
-    return true;   // TODO: perform some actual checks
-} 
 
 double Engine::getTime()
 {

--- a/components/engine/engine.hpp
+++ b/components/engine/engine.hpp
@@ -9,6 +9,8 @@
 #include <mission/mission_manager.hpp>
 #include <string>
 
+#include <base_loader.hpp>
+
 namespace MFGame
 {
 
@@ -72,6 +74,7 @@ public:
     MFGame::SpatialEntityFactory *getSpatialEntityFactory() { return mSpatialEntityFactory; };
     MFGame::SpatialEntityManager *getSpatialEntityManager() { return mSpatialEntityManager; };
     MFInput::InputManager *getInputManager()                { return mInputManager;         };
+    MFFormat::ModelCache *getModelCache()                   { return &mModelCache; };
 
     std::string getCameraInfoString();                     ///< Get camera position and rotation encoded in string.
     void setCameraFromString(std::string cameraString);    ///< For debug - set current camera from string returned by getCameraInfoString().
@@ -95,6 +98,8 @@ protected:
     MFPhysics::BulletPhysicsWorld       *mPhysicsWorld;
     MFGame::MissionManager              *mMissionManager;
     bool mIsRunning;
+
+    MFFormat::ModelCache mModelCache;
 
     EngineSettings mEngineSettings;
 };

--- a/components/engine/engine.hpp
+++ b/components/engine/engine.hpp
@@ -6,6 +6,7 @@
 #include <spatial_entity/manager.hpp>
 #include <spatial_entity/factory.hpp>
 #include <renderer/base_renderer.hpp>
+#include <mission/mission_manager.hpp>
 #include <string>
 
 namespace MFGame
@@ -65,7 +66,6 @@ public:
     virtual void run();
 
     bool loadMission(std::string missionName); 
-    bool loadSingleModel(std::string modelName); 
     bool exportScene(std::string outputFileName);
 
     MFRender::Renderer *getRenderer()                       { return mRenderer;             };
@@ -93,7 +93,7 @@ protected:
     MFGame::SpatialEntityFactory        *mSpatialEntityFactory;
     MFRender::OSGRenderer               *mRenderer;
     MFPhysics::BulletPhysicsWorld       *mPhysicsWorld;
-
+    MFGame::MissionManager              *mMissionManager;
     bool mIsRunning;
 
     EngineSettings mEngineSettings;

--- a/components/engine/engine.hpp
+++ b/components/engine/engine.hpp
@@ -73,6 +73,7 @@ public:
     MFGame::SpatialEntityFactory *getSpatialEntityFactory() { return mSpatialEntityFactory; };
     MFGame::SpatialEntityManager *getSpatialEntityManager() { return mSpatialEntityManager; };
     MFInput::InputManager *getInputManager()                { return mInputManager;         };
+    MFGame::MissionManager *getMissionManager()             { return mMissionManager; };
     
     std::string getCameraInfoString();                     ///< Get camera position and rotation encoded in string.
     void setCameraFromString(std::string cameraString);    ///< For debug - set current camera from string returned by getCameraInfoString().

--- a/components/engine/engine.hpp
+++ b/components/engine/engine.hpp
@@ -9,8 +9,6 @@
 #include <mission/mission_manager.hpp>
 #include <string>
 
-#include <base_loader.hpp>
-
 namespace MFGame
 {
 
@@ -71,11 +69,11 @@ public:
     bool exportScene(std::string outputFileName);
 
     MFRender::Renderer *getRenderer()                       { return mRenderer;             };
+    MFPhysics::BulletPhysicsWorld *getPhysicsWorld()        { return mPhysicsWorld; };
     MFGame::SpatialEntityFactory *getSpatialEntityFactory() { return mSpatialEntityFactory; };
     MFGame::SpatialEntityManager *getSpatialEntityManager() { return mSpatialEntityManager; };
     MFInput::InputManager *getInputManager()                { return mInputManager;         };
-    MFFormat::ModelCache *getModelCache()                   { return &mModelCache; };
-
+    
     std::string getCameraInfoString();                     ///< Get camera position and rotation encoded in string.
     void setCameraFromString(std::string cameraString);    ///< For debug - set current camera from string returned by getCameraInfoString().
     void RequestExit();
@@ -98,8 +96,6 @@ protected:
     MFPhysics::BulletPhysicsWorld       *mPhysicsWorld;
     MFGame::MissionManager              *mMissionManager;
     bool mIsRunning;
-
-    MFFormat::ModelCache mModelCache;
 
     EngineSettings mEngineSettings;
 };

--- a/components/klz/bullet_klz.cpp
+++ b/components/klz/bullet_klz.cpp
@@ -3,7 +3,7 @@
 namespace MFPhysics
 {
 
-void BulletTreeKlzLoader::load(std::ifstream &srcFile, MFFormat::DataFormat4DS &scene4ds)
+void BulletStaticCollisionLoader::load(std::ifstream &srcFile, MFFormat::DataFormat4DS &scene4ds)
 {
     MFFormat::DataFormatTreeKLZ klz;
     klz.load(srcFile);

--- a/components/klz/bullet_klz.cpp
+++ b/components/klz/bullet_klz.cpp
@@ -3,16 +3,13 @@
 namespace MFPhysics
 {
 
-void BulletStaticCollisionLoader::load(std::ifstream &srcFile, MFFormat::DataFormat4DS &scene4ds)
+void BulletStaticCollisionLoader::load(MFFormat::DataFormatTreeKLZ *klz, MFFormat::DataFormat4DS &scene4ds)
 {
-    MFFormat::DataFormatTreeKLZ klz;
-    klz.load(srcFile);
-
-    std::vector<std::string> linkStrings = klz.getLinkStrings();
+    std::vector<std::string> linkStrings = klz->getLinkStrings();
 
     #define loopBegin(getFunc)\
     {\
-        auto cols = klz.getFunc(); \
+        auto cols = klz->getFunc(); \
         for (int i = 0; i < (int) cols.size(); ++i)\
         {\
             auto col = cols[i];\
@@ -84,7 +81,7 @@ void BulletStaticCollisionLoader::load(std::ifstream &srcFile, MFFormat::DataFor
 
     // load face collisions:
 
-    auto cols = klz.getFaceCols();
+    auto cols = klz->getFaceCols();
 
     int currentLink = -1;
     MeshFaceCollision faceCol;

--- a/components/klz/bullet_klz.hpp
+++ b/components/klz/bullet_klz.hpp
@@ -21,7 +21,7 @@ namespace MFPhysics
 class BulletStaticCollisionLoader
 {
 public:
-    void load(std::ifstream &srcFile, MFFormat::DataFormat4DS &scene4ds);
+    void load(MFFormat::DataFormatTreeKLZ *klz, MFFormat::DataFormat4DS &scene4ds);
 
     std::vector<MFUtil::NamedRigidBody> mRigidBodies;
 

--- a/components/klz/bullet_klz.hpp
+++ b/components/klz/bullet_klz.hpp
@@ -18,7 +18,7 @@
 namespace MFPhysics
 {
 
-class BulletTreeKlzLoader
+class BulletStaticCollisionLoader
 {
 public:
     void load(std::ifstream &srcFile, MFFormat::DataFormat4DS &scene4ds);

--- a/components/mission/mission.cpp
+++ b/components/mission/mission.cpp
@@ -3,7 +3,7 @@
 namespace MFGame
 {
 
-Mission::Mission()
+Mission::Mission(std::string missionName): mMissionName(missionName)
 {
 
 }

--- a/components/mission/mission.cpp
+++ b/components/mission/mission.cpp
@@ -1,0 +1,16 @@
+#include "mission/mission.hpp"
+
+namespace MFGame
+{
+
+Mission::Mission()
+{
+
+}
+
+Mission::~Mission()
+{
+
+}
+
+}

--- a/components/mission/mission.hpp
+++ b/components/mission/mission.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace MFGame
+{
+
+class Mission
+{
+public:
+    Mission();
+    virtual ~Mission() = 0;
+
+    virtual bool load()=0;
+    virtual bool unload()=0;
+    virtual bool importFile()=0;
+    virtual bool exportFile()=0;
+};
+
+}

--- a/components/mission/mission.hpp
+++ b/components/mission/mission.hpp
@@ -1,18 +1,25 @@
 #pragma once
 
+#include <string>
+
 namespace MFGame
 {
 
 class Mission
 {
 public:
-    Mission();
+    Mission(std::string missionName);
     virtual ~Mission() = 0;
 
     virtual bool load()=0;
     virtual bool unload()=0;
     virtual bool importFile()=0;
     virtual bool exportFile()=0;
+
+protected:
+    std::string mMissionName;
+
+
 };
 
 }

--- a/components/mission/mission_impl.cpp
+++ b/components/mission/mission_impl.cpp
@@ -3,8 +3,10 @@
 namespace MFGame
 {
 
-MissionImpl::MissionImpl(): Mission()
+MissionImpl::MissionImpl(std::string missionName, MFRender::OSGRenderer *renderer): Mission(missionName)
 {
+    mFileSystem = MFFile::FileSystem::getInstance();
+    mRenderer = renderer;
 }
 
 MissionImpl::~MissionImpl()
@@ -13,6 +15,93 @@ MissionImpl::~MissionImpl()
 
 bool MissionImpl::load()
 {
+    std::string missionDir = "missions/" + mMissionName;
+    std::string scene4dsPath = missionDir + "/scene.4ds";
+    std::string scene2BinPath = missionDir + "/scene2.bin";
+    std::string cacheBinPath = missionDir + "/cache.bin";
+    std::string checkBinPath = missionDir + "/check.bin";
+
+    std::ifstream file4DS;
+    std::ifstream fileScene2Bin;
+    std::ifstream fileCacheBin;
+    std::ifstream fileCheckBin;
+
+    MFFormat::OSG4DSLoader l4ds;
+    MFFormat::OSGScene2BinLoader lScene2;
+    MFFormat::OSGCacheBinLoader lCache;
+
+    l4ds.setLoaderCache(mRenderer->getLoaderCache());
+    lScene2.setLoaderCache(mRenderer->getLoaderCache());
+    lCache.setLoaderCache(mRenderer->getLoaderCache());
+
+    MFFormat::OSGLoader::NodeMap nodeMap;
+    l4ds.setNodeMap(&nodeMap);
+    lScene2.setNodeMap(&nodeMap);
+
+    if (mFileSystem->open(file4DS, scene4dsPath)) {
+        mSceneModel.load(file4DS);
+        file4DS.close();
+
+        osg::ref_ptr<osg::Node> n = l4ds.load(&mSceneModel);
+        mRenderer->getRootNode()->addChild(n);
+    }
+    else
+        MFLogger::Logger::warn("Could not open 4ds file: " + scene4dsPath + ".", OSGRENDERER_MODULE_STR);
+    
+    bool lightsAreSet = false;
+
+    float viewDistance = 2000;    // default value
+
+    if (mFileSystem->open(fileScene2Bin, scene2BinPath))
+    {
+        mSceneData.load(fileScene2Bin);
+        osg::ref_ptr<osg::Node> n = lScene2.load(&mSceneData);
+
+        if (!n)
+            MFLogger::Logger::warn("Could not parse scene2.bin file: " + scene2BinPath + ".", OSGRENDERER_MODULE_STR);
+        else
+        {
+            mRenderer->getRootNode()->addChild(n);
+            std::vector<osg::ref_ptr<osg::LightSource>> lightNodes = lScene2.getLightNodes();
+            mRenderer->setUpLights(&lightNodes);
+            lightsAreSet = true;
+            viewDistance = lScene2.getViewDistance();
+        }
+
+        fileScene2Bin.close();
+    }
+
+    if (!lightsAreSet)
+        mRenderer->setUpLights(nullptr);
+
+    if (mFileSystem->open(fileCacheBin, cacheBinPath))
+    {
+        mCacheData.load(fileCacheBin);
+        osg::ref_ptr<osg::Node> n = lCache.load(&mCacheData);
+
+        if (!n)
+            MFLogger::Logger::warn("Could not parse cache.bin file: " + cacheBinPath + ".", OSGRENDERER_MODULE_STR);
+        else
+            mRenderer->getRootNode()->addChild(n);
+
+        fileCacheBin.close();
+    }
+
+    ////NOTE(DavoSK): Only for debug 
+    //if (mFileSystem->open(fileCheckBin, checkBinPath))
+    //{
+    //    osg::ref_ptr<osg::Node> n = lCheck.load(fileCheckBin);
+    //    if (!n)
+    //        MFLogger::Logger::warn("Couldn't not parse check.bin file: " + checkBinPath + ".", OSGRENDERER_MODULE_STR);
+    //    else
+    //        mRootNode->addChild(n);
+
+    //    fileCheckBin.close();
+    //}
+
+    //setViewDistance(viewDistance);
+    //optimize();
+    //mLoaderCache.logStats();
     return false;
 }
 

--- a/components/mission/mission_impl.cpp
+++ b/components/mission/mission_impl.cpp
@@ -33,13 +33,13 @@ bool MissionImpl::load()
     MFFormat::OSGModelLoader l4ds;
     MFFormat::OSGStaticSceneLoader lScene2;
     MFFormat::OSGCachedCityLoader lCache;
+    MFPhysics::BulletStaticCollisionLoader lTreeKlz;
 
     l4ds.setLoaderCache(mRenderer->getLoaderCache());
     lScene2.setLoaderCache(mRenderer->getLoaderCache());
     lScene2.setObjectFactory(mEngine->getSpatialEntityFactory());
     lCache.setLoaderCache(mRenderer->getLoaderCache());
     lCache.setObjectFactory(mEngine->getSpatialEntityFactory());
-
     
     l4ds.setNodeMap(&mNodeMap);
     lScene2.setNodeMap(&mNodeMap);
@@ -96,6 +96,15 @@ bool MissionImpl::load()
     if (mFileSystem->open(fileTreeKlz, treeKlzPath)) {
         mStaticColsData.load(fileTreeKlz);
         fileTreeKlz.close();
+    }
+
+    lTreeKlz.load(&mStaticColsData, mSceneModel);
+    mEngine->getPhysicsWorld()->setTreeKlzBodies(lTreeKlz.mRigidBodies);
+    auto treeKlzBodies = lTreeKlz.mRigidBodies;
+    for (int i = 0; i < (int)treeKlzBodies.size(); ++i)
+    {
+        treeKlzBodies[i].mRigidBody.mBody->setActivationState(0);
+        mEngine->getPhysicsWorld()->getWorld()->addRigidBody(treeKlzBodies[i].mRigidBody.mBody.get());
     }
 
     ////NOTE(DavoSK): Only for debug 

--- a/components/mission/mission_impl.cpp
+++ b/components/mission/mission_impl.cpp
@@ -266,6 +266,13 @@ void MissionImpl::createMissionEntities()
                     }
                     break;
 
+                    case MFFormat::DataFormatScene2BIN::SPECIAL_OBJECT_TYPE_CHARACTER:
+                    {
+                        auto entityId = mEngine->getSpatialEntityFactory()->createPawnEntity(object.mModelName, 0.0f);
+                        entity = (MFGame::SpatialEntityImpl *)mEngine->getSpatialEntityManager()->getEntityById(entityId);
+                    }
+                    break;
+
                     default:
                         break;
                 }

--- a/components/mission/mission_impl.cpp
+++ b/components/mission/mission_impl.cpp
@@ -263,7 +263,6 @@ void MissionImpl::createMissionEntities()
                     {
                         auto entityId = mEngine->getSpatialEntityFactory()->createDynamicEntity(&object);
                         entity = (MFGame::SpatialEntityImpl *)mEngine->getSpatialEntityManager()->getEntityById(entityId);
-                        printf("%s\n", entity->getName().c_str());
                     }
                     break;
 
@@ -300,11 +299,12 @@ void MissionImpl::createMissionEntities()
             entity->setRotation(rot);
         }
         else {
-            auto pos = object.mPos;
-            auto rot = object.mRot;
+            MFFormat::OSGStaticSceneLoader l;
+            auto pos = l.toOSG(object.mPos);
+            auto rot = l.toOSG(object.mRot);
 
-            entity->setPosition(pos);
-            entity->setRotation(rot);
+            entity->setPosition(MFMath::Vec3(pos.x(), pos.y(), pos.z()));
+            entity->setRotation(MFMath::Quat(rot.x(), rot.y(), rot.z(), rot.w()));
         }
     }
 }

--- a/components/mission/mission_impl.cpp
+++ b/components/mission/mission_impl.cpp
@@ -9,6 +9,7 @@ MissionImpl::MissionImpl(std::string missionName, MFGame::Engine *engine): Missi
     mFileSystem = MFFile::FileSystem::getInstance();
     mRenderer = (MFRender::OSGRenderer *)engine->getRenderer();
     mEngine = engine;
+    mModelCache = mEngine->getModelCache();
 }
 
 MissionImpl::~MissionImpl()
@@ -22,21 +23,23 @@ bool MissionImpl::load()
     std::string scene2BinPath = missionDir + "/scene2.bin";
     std::string cacheBinPath = missionDir + "/cache.bin";
     std::string checkBinPath = missionDir + "/check.bin";
+    std::string treeKlzPath = missionDir + "/tree.klz";
 
     std::ifstream file4DS;
     std::ifstream fileScene2Bin;
     std::ifstream fileCacheBin;
     std::ifstream fileCheckBin;
+    std::ifstream fileTreeKlz;
 
-    MFFormat::OSG4DSLoader l4ds;
+    MFFormat::OSGModelLoader l4ds;
     MFFormat::OSGStaticSceneLoader lScene2;
     MFFormat::OSGCachedCityLoader lCache;
 
     l4ds.setLoaderCache(mRenderer->getLoaderCache());
     lScene2.setLoaderCache(mRenderer->getLoaderCache());
-    lScene2.setModelCache(&mModelCache);
+    lScene2.setObjectFactory(mEngine->getSpatialEntityFactory());
     lCache.setLoaderCache(mRenderer->getLoaderCache());
-    lCache.setModelCache(&mModelCache);
+    lCache.setObjectFactory(mEngine->getSpatialEntityFactory());
 
     MFFormat::OSGLoader::NodeMap nodeMap;
     l4ds.setNodeMap(&nodeMap);
@@ -91,6 +94,11 @@ bool MissionImpl::load()
         fileCacheBin.close();
     }
 
+    if (mFileSystem->open(fileTreeKlz, treeKlzPath)) {
+        mStaticColsData.load(fileTreeKlz);
+        fileTreeKlz.close();
+    }
+
     ////NOTE(DavoSK): Only for debug 
     //if (mFileSystem->open(fileCheckBin, checkBinPath))
     //{
@@ -137,7 +145,7 @@ void MissionImpl::createMissionEntities()
                 switch (object.mSpecialType) {
                     case MFFormat::DataFormatScene2BIN::SPECIAL_OBJECT_TYPE_PHYSICAL:
                     {
-                        MFFormat::OSG4DSLoader model;
+                        MFFormat::OSGModelLoader model;
                     }
                     break;
 

--- a/components/mission/mission_impl.cpp
+++ b/components/mission/mission_impl.cpp
@@ -268,7 +268,7 @@ void MissionImpl::createMissionEntities()
 
                     case MFFormat::DataFormatScene2BIN::SPECIAL_OBJECT_TYPE_CHARACTER:
                     {
-                        auto entityId = mEngine->getSpatialEntityFactory()->createPawnEntity(object.mModelName, 0.0f);
+                        auto entityId = mEngine->getSpatialEntityFactory()->createPawnEntity(object.mModelName, 1000.0f);
                         entity = (MFGame::SpatialEntityImpl *)mEngine->getSpatialEntityManager()->getEntityById(entityId);
                     }
                     break;

--- a/components/mission/mission_impl.cpp
+++ b/components/mission/mission_impl.cpp
@@ -1,0 +1,34 @@
+#include "mission/mission_impl.hpp"
+
+namespace MFGame
+{
+
+MissionImpl::MissionImpl(): Mission()
+{
+}
+
+MissionImpl::~MissionImpl()
+{
+}
+
+bool MissionImpl::load()
+{
+    return false;
+}
+
+bool MissionImpl::unload()
+{
+    return false;
+}
+
+bool MissionImpl::importFile()
+{
+    return false;
+}
+
+bool MissionImpl::exportFile()
+{
+    return false;
+}
+
+}

--- a/components/mission/mission_impl.cpp
+++ b/components/mission/mission_impl.cpp
@@ -261,7 +261,7 @@ void MissionImpl::createMissionEntities()
                 switch (object.mSpecialType) {
                     case MFFormat::DataFormatScene2BIN::SPECIAL_OBJECT_TYPE_PHYSICAL:
                     {
-                        auto entityId = mEngine->getSpatialEntityFactory()->createDynamicEntity(&object);
+                        auto entityId = mEngine->getSpatialEntityFactory()->createPropEntity(&object);
                         entity = (MFGame::SpatialEntityImpl *)mEngine->getSpatialEntityManager()->getEntityById(entityId);
                     }
                     break;

--- a/components/mission/mission_impl.cpp
+++ b/components/mission/mission_impl.cpp
@@ -9,7 +9,6 @@ MissionImpl::MissionImpl(std::string missionName, MFGame::Engine *engine): Missi
     mFileSystem = MFFile::FileSystem::getInstance();
     mRenderer = (MFRender::OSGRenderer *)engine->getRenderer();
     mEngine = engine;
-    mModelCache = mEngine->getModelCache();
 }
 
 MissionImpl::~MissionImpl()
@@ -41,9 +40,9 @@ bool MissionImpl::load()
     lCache.setLoaderCache(mRenderer->getLoaderCache());
     lCache.setObjectFactory(mEngine->getSpatialEntityFactory());
 
-    MFFormat::OSGLoader::NodeMap nodeMap;
-    l4ds.setNodeMap(&nodeMap);
-    lScene2.setNodeMap(&nodeMap);
+    
+    l4ds.setNodeMap(&mNodeMap);
+    lScene2.setNodeMap(&mNodeMap);
 
     if (mFileSystem->open(file4DS, scene4dsPath)) {
         if (!mSceneModel.load(file4DS)) return false;
@@ -134,10 +133,127 @@ bool MissionImpl::exportFile()
     return false;
 }
 
+class CreateEntitiesFromSceneVisitor : public osg::NodeVisitor
+{
+public:
+    CreateEntitiesFromSceneVisitor(std::vector<MFUtil::NamedRigidBody> *treeKlzBodies, MFGame::SpatialEntityFactory *entityFactory) : osg::NodeVisitor()
+    {
+        mTreeKlzBodies = treeKlzBodies;
+        mEntityFactory = entityFactory;
+        mModelName = "";
+
+        for (int i = 0; i < (int)treeKlzBodies->size(); ++i)
+        {
+            std::string name = (*treeKlzBodies)[i].mName;
+            mNameToBody.insert(std::pair<std::string, MFUtil::NamedRigidBody *>(name, &((*treeKlzBodies)[i])));
+        }
+    }
+
+    virtual void apply(osg::Node &n) override
+    {
+        MFUtil::traverse(this, n);
+    }
+
+    virtual void apply(osg::MatrixTransform &n) override
+    {
+        std::string modelName = "";
+
+        if (n.getUserDataContainer())
+        {
+            std::vector<std::string> descriptions = n.getUserDataContainer()->getDescriptions();
+
+            if (descriptions.size() > 0)
+            {
+                if (descriptions[0].compare("scene2.bin model") == 0)
+                {
+                    modelName = n.getName();
+                }
+                else if (descriptions[0].compare("4ds mesh") == 0)
+                {
+                    std::vector<MFUtil::NamedRigidBody *> matches = findCollisions(n.getName());
+                    std::string fullName = mModelName.length() > 0 ? mModelName + "." + n.getName() : n.getName();
+
+                    if (matches.size() == 0)
+                    {
+                        MFLogger::Logger::warn("Could not find matching collision for visual node \"" + n.getName() + "\" (model: \"" + mModelName + "\").", SPATIAL_ENTITY_FACTORY_MODULE_STR);
+                        mEntityFactory->createEntity(&n, 0, 0, fullName);
+                    }
+                    else
+                    {
+                        for (int i = 0; i < (int)matches.size(); ++i)
+                        {
+                            mEntityFactory->createEntity(&n, matches[i]->mRigidBody.mBody, matches[i]->mRigidBody.mMotionState, fullName);
+                            mMatchedBodies.insert(matches[i]->mName);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (modelName.size() > 0)
+            mModelName = modelName;          // traverse downwards with given name prefix
+
+        MFUtil::traverse(this, n);
+
+        if (modelName.size() > 0)
+            mModelName = "";                 // going back up => clear the name prefix
+    }
+
+    std::set<std::string> mMatchedBodies;
+
+protected:
+    std::vector<MFUtil::NamedRigidBody> *mTreeKlzBodies;
+    MFGame::SpatialEntityFactory *mEntityFactory;
+    std::string mModelName;                  // when traversing into a model loaded from scene2.bin, this will contain the model name (needed as the name prefix)
+    std::multimap<std::string, MFUtil::NamedRigidBody *> mNameToBody;
+
+    std::vector<MFUtil::NamedRigidBody *> findCollisions(std::string visualName)
+    {
+        std::vector<MFUtil::NamedRigidBody *> result;
+
+        auto found = mNameToBody.equal_range(visualName);
+
+        for (auto it = found.first; it != found.second; ++it)
+            result.push_back(it->second);
+
+        found = mNameToBody.equal_range(mModelName);
+
+        for (auto it = found.first; it != found.second; ++it)
+            result.push_back(it->second);
+
+        found = mNameToBody.equal_range(mModelName + "." + visualName);
+
+        for (auto it = found.first; it != found.second; ++it)
+            result.push_back(it->second);
+
+        return result;
+    }
+};
+
 void MissionImpl::createMissionEntities()
 {
+    auto treeKlzBodies = mEngine->getPhysicsWorld()->getTreeKlzBodies();
+
+    CreateEntitiesFromSceneVisitor v(&treeKlzBodies, mEngine->getSpatialEntityFactory());
+    mRenderer->getRootNode()->accept(v);
+
+    // process the unmatched rigid bodies:
+
+    for (int i = 0; i < (int)treeKlzBodies.size(); ++i)
+    {
+        if (v.mMatchedBodies.find(treeKlzBodies[i].mName) != v.mMatchedBodies.end())
+            continue;
+
+        mEngine->getSpatialEntityFactory()->createEntity(0,
+            treeKlzBodies[i].mRigidBody.mBody,
+            treeKlzBodies[i].mRigidBody.mMotionState,
+            treeKlzBodies[i].mName);
+    }
+
     for (auto pair : mSceneData.getObjects()) {
         auto object = pair.second;
+
+        MFGame::SpatialEntityImpl *entity = nullptr;
 
         switch (object.mType) {
             case MFFormat::DataFormatScene2BIN::OBJECT_TYPE_MODEL:
@@ -145,7 +261,9 @@ void MissionImpl::createMissionEntities()
                 switch (object.mSpecialType) {
                     case MFFormat::DataFormatScene2BIN::SPECIAL_OBJECT_TYPE_PHYSICAL:
                     {
-                        MFFormat::OSGModelLoader model;
+                        auto entityId = mEngine->getSpatialEntityFactory()->createDynamicEntity(&object);
+                        entity = (MFGame::SpatialEntityImpl *)mEngine->getSpatialEntityManager()->getEntityById(entityId);
+                        printf("%s\n", entity->getName().c_str());
                     }
                     break;
 
@@ -157,6 +275,36 @@ void MissionImpl::createMissionEntities()
 
             default:
                 break;
+        }
+
+        if (!entity) continue;
+
+        auto it = mNodeMap.find(object.mParentName);
+
+
+        if (it != mNodeMap.end()) {
+            auto parent = (osg::MatrixTransform *)it->second.get();
+            osg::Vec3f oPos = parent->getMatrix().getTrans();
+            osg::Quat oRot = parent->getMatrix().getRotate();
+            osg::Vec3f oScale = parent->getMatrix().getScale();
+
+            // TODO make sure entity starts at transform calculated from his parent
+            //auto pos = MFMath::Vec3(oPos.x(), oPos.y(), oPos.z());
+            //auto rot = MFMath::Quat(oRot.x(), oRot.y(), oRot.z(), oRot.w());
+            //auto scale = MFMath::Vec3(oScale.x(), oScale.y(), oScale.z());
+
+            auto pos = object.mPos;
+            auto rot = object.mRot;
+
+            entity->setPosition(pos);
+            entity->setRotation(rot);
+        }
+        else {
+            auto pos = object.mPos;
+            auto rot = object.mRot;
+
+            entity->setPosition(pos);
+            entity->setRotation(rot);
         }
     }
 }

--- a/components/mission/mission_impl.hpp
+++ b/components/mission/mission_impl.hpp
@@ -33,6 +33,7 @@
 // ---
 
 #include "scene2_bin/parser_scene2bin.hpp"
+#include "klz/parser_klz.hpp"
 #include "renderer/osg_renderer.hpp"
 
 namespace MFGame
@@ -55,8 +56,9 @@ protected:
     MFFormat::DataFormat4DS mSceneModel;
     MFFormat::DataFormatScene2BIN mSceneData;
     MFFormat::DataFormatCacheBIN mCacheData;
+    MFFormat::DataFormatTreeKLZ mStaticColsData;
 
-    MFFormat::ModelCache mModelCache;
+    MFFormat::ModelCache *mModelCache;
 
 private:
     MFFile::FileSystem *mFileSystem;

--- a/components/mission/mission_impl.hpp
+++ b/components/mission/mission_impl.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "mission/mission.hpp"
+
+namespace MFGame
+{
+
+class MissionImpl: public Mission
+{
+public:
+    MissionImpl();
+    virtual ~MissionImpl() override;
+
+    virtual bool load() override;
+    virtual bool unload() override;
+    virtual bool importFile() override;
+    virtual bool exportFile() override;
+};
+
+}

--- a/components/mission/mission_impl.hpp
+++ b/components/mission/mission_impl.hpp
@@ -5,32 +5,11 @@
 
 #include <osg/Group>
 
-// --- CLEANUP
-#include <renderer/base_renderer.hpp>
-#include <osg/Node>
-#include <osgDB/ReadFile>
-#include <osgViewer/Viewer>
-#include <4ds/osg_4ds.hpp>
 #include <scene2_bin/osg_scene2bin.hpp>
 #include <cache_bin/osg_cachebin.hpp>
 #include <check_bin/osg_checkbin.hpp>
-#include <osg/Texture2D>
-#include <osg/LightModel>
-#include <utils/logger.hpp>
-#include <osgGA/TrackballManipulator>
-#include <loader_cache.hpp>
-#include <osgViewer/ViewerEventHandlers>
-#include <osgUtil/Optimizer>
-#include <osg/Fog>
-#include <osgUtil/PrintVisitor>
 #include <vfs/vfs.hpp>
-#include <osg/MatrixTransform>
-#include <fstream>
-#include <utils/logger.hpp>
-#include <vfs/vfs.hpp>
-#include <loader_cache.hpp>
 #include <utils/math.hpp>
-// ---
 
 #include "scene2_bin/parser_scene2bin.hpp"
 #include "klz/parser_klz.hpp"

--- a/components/mission/mission_impl.hpp
+++ b/components/mission/mission_impl.hpp
@@ -1,6 +1,39 @@
 #pragma once
 
 #include "mission/mission.hpp"
+#include "vfs/vfs.hpp"
+
+#include <osg/Group>
+
+// --- CLEANUP
+#include <renderer/base_renderer.hpp>
+#include <osg/Node>
+#include <osgDB/ReadFile>
+#include <osgViewer/Viewer>
+#include <4ds/osg_4ds.hpp>
+#include <scene2_bin/osg_scene2bin.hpp>
+#include <cache_bin/osg_cachebin.hpp>
+#include <check_bin/osg_checkbin.hpp>
+#include <osg/Texture2D>
+#include <osg/LightModel>
+#include <utils/logger.hpp>
+#include <osgGA/TrackballManipulator>
+#include <loader_cache.hpp>
+#include <osgViewer/ViewerEventHandlers>
+#include <osgUtil/Optimizer>
+#include <osg/Fog>
+#include <osgUtil/PrintVisitor>
+#include <vfs/vfs.hpp>
+#include <osg/MatrixTransform>
+#include <fstream>
+#include <utils/logger.hpp>
+#include <vfs/vfs.hpp>
+#include <loader_cache.hpp>
+#include <utils/math.hpp>
+// ---
+
+#include "scene2_bin/parser_scene2bin.hpp"
+#include "renderer/osg_renderer.hpp"
 
 namespace MFGame
 {
@@ -8,13 +41,23 @@ namespace MFGame
 class MissionImpl: public Mission
 {
 public:
-    MissionImpl();
+    MissionImpl(std::string missionName, MFRender::OSGRenderer *renderer);
     virtual ~MissionImpl() override;
 
     virtual bool load() override;
     virtual bool unload() override;
     virtual bool importFile() override;
     virtual bool exportFile() override;
+
+protected:
+    MFFormat::DataFormat4DS mSceneModel;
+    MFFormat::DataFormatScene2BIN mSceneData;
+    MFFormat::DataFormatCacheBIN mCacheData;
+
+private:
+    MFFile::FileSystem *mFileSystem;
+    MFRender::OSGRenderer *mRenderer;
+
 };
 
 }

--- a/components/mission/mission_impl.hpp
+++ b/components/mission/mission_impl.hpp
@@ -58,7 +58,7 @@ protected:
     MFFormat::DataFormatCacheBIN mCacheData;
     MFFormat::DataFormatTreeKLZ mStaticColsData;
 
-    MFFormat::ModelCache *mModelCache;
+    MFFormat::OSGLoader::NodeMap mNodeMap;
 
 private:
     MFFile::FileSystem *mFileSystem;

--- a/components/mission/mission_impl.hpp
+++ b/components/mission/mission_impl.hpp
@@ -31,6 +31,8 @@ public:
     virtual bool importFile() override;
     virtual bool exportFile() override;
 
+    MFFormat::DataFormatScene2BIN *getSceneData() { return &mSceneData; }
+
 protected:
     MFFormat::DataFormat4DS mSceneModel;
     MFFormat::DataFormatScene2BIN mSceneData;

--- a/components/mission/mission_impl.hpp
+++ b/components/mission/mission_impl.hpp
@@ -38,10 +38,12 @@
 namespace MFGame
 {
 
+    class Engine;
+
 class MissionImpl: public Mission
 {
 public:
-    MissionImpl(std::string missionName, MFRender::OSGRenderer *renderer);
+    MissionImpl(std::string missionName, MFGame::Engine *engine);
     virtual ~MissionImpl() override;
 
     virtual bool load() override;
@@ -54,9 +56,14 @@ protected:
     MFFormat::DataFormatScene2BIN mSceneData;
     MFFormat::DataFormatCacheBIN mCacheData;
 
+    MFFormat::ModelCache mModelCache;
+
 private:
     MFFile::FileSystem *mFileSystem;
     MFRender::OSGRenderer *mRenderer;
+    MFGame::Engine *mEngine;
+
+    void createMissionEntities();
 
 };
 

--- a/components/mission/mission_manager.cpp
+++ b/components/mission/mission_manager.cpp
@@ -21,10 +21,13 @@ void MissionManager::loadMission(std::string missionName)
         mCurrentMission = it->second;
     }
     else {
-        Mission *mission = new MissionImpl(missionName, (MFRender::OSGRenderer*)mEngine->getRenderer());
+        Mission *mission = new MissionImpl(missionName, mEngine);
         if (mission->load()) {
             mCurrentMission = mission;
             mMissions.insert(std::make_pair(missionName, mission));
+        }
+        else {
+            MFLogger::Logger::fatal("Could not load mission: " + missionName, MISSION_MANAGER_MODULE_STR);
         }
     }
 }

--- a/components/mission/mission_manager.cpp
+++ b/components/mission/mission_manager.cpp
@@ -1,6 +1,32 @@
 #include "mission/mission_manager.hpp"
+#include "mission/mission_impl.hpp"
+#include "engine/engine.hpp"
 
 namespace MFGame
 {
+
+MissionManager::MissionManager(MFGame::Engine *engine)
+{
+    mEngine = engine;
+}
+
+void MissionManager::loadMission(std::string missionName)
+{
+    auto it = mMissions.find(missionName);
+
+    if (it != mMissions.end()) {
+        if (mCurrentMission && mCurrentMission != it->second) {
+            mCurrentMission->unload();
+        }
+        mCurrentMission = it->second;
+    }
+    else {
+        Mission *mission = new MissionImpl(missionName, (MFRender::OSGRenderer*)mEngine->getRenderer());
+        if (mission->load()) {
+            mCurrentMission = mission;
+            mMissions.insert(std::make_pair(missionName, mission));
+        }
+    }
+}
 
 }

--- a/components/mission/mission_manager.cpp
+++ b/components/mission/mission_manager.cpp
@@ -1,0 +1,6 @@
+#include "mission/mission_manager.hpp"
+
+namespace MFGame
+{
+
+}

--- a/components/mission/mission_manager.hpp
+++ b/components/mission/mission_manager.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#define MISSION_MANAGER_MODULE_STR "MissionManager"
+
 #include "mission/mission.hpp"
 
 #include <unordered_map>

--- a/components/mission/mission_manager.hpp
+++ b/components/mission/mission_manager.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#define MISSION_MANAGER_MODULE_STR "MissionManager"
+#define MISSION_MANAGER_MODULE_STR "mission manager"
 
 #include "mission/mission.hpp"
 

--- a/components/mission/mission_manager.hpp
+++ b/components/mission/mission_manager.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "mission/mission.hpp"
+
+namespace MFGame
+{
+
+class MissionManager 
+{
+public:
+    MissionManager();
+    ~MissionManager() = default;
+
+
+};
+
+}

--- a/components/mission/mission_manager.hpp
+++ b/components/mission/mission_manager.hpp
@@ -18,6 +18,7 @@ public:
     ~MissionManager() = default;
 
     void loadMission(std::string missionName);
+    Mission *getCurrentMission() { return mCurrentMission; }
 
 private:
     MFGame::Engine *mEngine;

--- a/components/mission/mission_manager.hpp
+++ b/components/mission/mission_manager.hpp
@@ -2,16 +2,25 @@
 
 #include "mission/mission.hpp"
 
+#include <unordered_map>
+
 namespace MFGame
 {
-
+    typedef std::unordered_map<std::string, MFGame::Mission*> MissionPair;
+    class Engine;
+    
 class MissionManager 
 {
 public:
-    MissionManager();
+    MissionManager(MFGame::Engine *engine);
     ~MissionManager() = default;
 
+    void loadMission(std::string missionName);
 
+private:
+    MFGame::Engine *mEngine;
+    MissionPair mMissions;
+    Mission *mCurrentMission;
 };
 
 }

--- a/components/physics/base_physics_world.hpp
+++ b/components/physics/base_physics_world.hpp
@@ -16,7 +16,6 @@ class PhysicsWorld
 public:
     virtual ~PhysicsWorld() {};
     virtual void frame(double dt)=0;
-    virtual bool loadMission(std::string mission)=0;
     virtual void getWorldAABBox(MFMath::Vec3 &min, MFMath::Vec3 &max)=0;
 
     /**

--- a/components/physics/bullet_physics_world.cpp
+++ b/components/physics/bullet_physics_world.cpp
@@ -158,7 +158,7 @@ bool BulletPhysicsWorld::loadMission(std::string mission)
     std::ifstream fileTreeKlz;
     std::ifstream fileScene4ds;
 
-    BulletTreeKlzLoader treeKlzLoader;
+    BulletStaticCollisionLoader treeKlzLoader;
     MFFormat::DataFormat4DS loader4DS;
 
     if (!mFileSystem->open(fileScene4ds,scene4dsPath))    // FIXME: parsed files should be retrieved from LoaderCache to avoid parsing the same file twice

--- a/components/physics/bullet_physics_world.cpp
+++ b/components/physics/bullet_physics_world.cpp
@@ -147,47 +147,4 @@ std::vector<MFUtil::NamedRigidBody> BulletPhysicsWorld::getTreeKlzBodies()
     return mTreeKlzBodies;
 }
 
-bool BulletPhysicsWorld::loadMission(std::string mission)
-{
-    MFLogger::Logger::info("Loading physics world for mission " + mission + ".",BULLET_PHYSICS_WORLD_MODULE_STR);
-
-    std::string missionDir = "missions/" + mission;
-    std::string treeKlzPath = missionDir + "/tree.klz";
-    std::string scene4dsPath = missionDir + "/scene.4ds";
-
-    std::ifstream fileTreeKlz;
-    std::ifstream fileScene4ds;
-
-    BulletStaticCollisionLoader treeKlzLoader;
-    MFFormat::DataFormat4DS loader4DS;
-
-    if (!mFileSystem->open(fileScene4ds,scene4dsPath))    // FIXME: parsed files should be retrieved from LoaderCache to avoid parsing the same file twice
-    {
-        MFLogger::Logger::warn("Couldn't open scene.4ds file: " + treeKlzPath + ".",BULLET_PHYSICS_WORLD_MODULE_STR);
-        return false;
-    }
-
-    if (mFileSystem->open(fileTreeKlz,treeKlzPath))
-    {
-        loader4DS.load(fileScene4ds);
-        treeKlzLoader.load(fileTreeKlz,loader4DS);
-        mTreeKlzBodies = treeKlzLoader.mRigidBodies; 
-        fileTreeKlz.close();
-
-        for (int i = 0; i < (int) mTreeKlzBodies.size(); ++i)
-        {
-            mTreeKlzBodies[i].mRigidBody.mBody->setActivationState(0);
-            mWorld->addRigidBody(mTreeKlzBodies[i].mRigidBody.mBody.get()); 
-        }
-    }
-    else
-    {
-        fileScene4ds.close();
-        MFLogger::Logger::warn("Couldn't open tree.klz file: " + treeKlzPath + ".",BULLET_PHYSICS_WORLD_MODULE_STR);
-        return false;
-    }
-
-    return true;
-}
-
 }

--- a/components/physics/bullet_physics_world.hpp
+++ b/components/physics/bullet_physics_world.hpp
@@ -20,13 +20,13 @@ public:
     BulletPhysicsWorld();
     virtual ~BulletPhysicsWorld();
     virtual void frame(double dt) override;
-    virtual bool loadMission(std::string mission) override;
     virtual MFGame::SpatialEntity::Id pointCollision(MFMath::Vec3 position) override;
     virtual double castRay(MFMath::Vec3 origin, MFMath::Vec3 direction) override;
     virtual void getWorldAABBox(MFMath::Vec3 &min, MFMath::Vec3 &max) override;
     btDiscreteDynamicsWorld *getWorld() { return mWorld; }
 
     std::vector<MFUtil::NamedRigidBody> getTreeKlzBodies();
+    void setTreeKlzBodies(std::vector<MFUtil::NamedRigidBody> bodies) { mTreeKlzBodies = bodies; };
 protected:
     btDiscreteDynamicsWorld             *mWorld;
     btBroadphaseInterface               *mBroadphaseInterface;

--- a/components/renderer/base_renderer.hpp
+++ b/components/renderer/base_renderer.hpp
@@ -12,8 +12,6 @@ class Renderer
 public:
     Renderer() { mDone = false; };
     virtual ~Renderer() {};
-    virtual bool loadMission(std::string mission, bool load4ds=true, bool loadScene2Bin=true, bool loadCacheBin=true)=0;
-    virtual bool loadSingleModel(std::string model)=0;
     virtual void frame(double dt)=0;
     virtual void setCameraParameters(bool perspective,  float fov,  float orthoSize,  float nearDist,  float farDist)=0;
     virtual void getCameraParameters(bool &perspective, float &fov, float &orthoSize, float &nearDist, float &farDist)=0;

--- a/components/renderer/osg_renderer.hpp
+++ b/components/renderer/osg_renderer.hpp
@@ -33,8 +33,6 @@ class OSGRenderer: public Renderer
 {
 public:
     OSGRenderer();
-    virtual bool loadMission(std::string mission, bool load4ds=true, bool loadScene2Bin=true, bool loadCacheBin=true) override;
-    virtual bool loadSingleModel(std::string model) override;
     virtual void frame(double dt) override;
     virtual void setCameraParameters(bool perspective,  float fov,  float orthoSize,  float nearDist,  float farDist) override;
     virtual void getCameraParameters(bool &perspective, float &fov, float &orthoSize, float &nearDist, float &farDist) override;
@@ -62,6 +60,13 @@ public:
 
     virtual void cameraFace(MFMath::Vec3 position) override;
 
+    /**
+    Given a list of light sources in the scene, the function decides which scene node should be lit by which
+    light and applies this decision to the lights and scene, adds a defaults light if there is none etc.
+    */
+
+    void setUpLights(std::vector<osg::ref_ptr<osg::LightSource>> *lightNodes);
+
 protected:
     osg::ref_ptr<osgViewer::Viewer> mViewer;    
     osg::ref_ptr<osg::Group> mRootNode;            ///< root node of the whole scene being rendered
@@ -70,13 +75,6 @@ protected:
     OSGCache mLoaderCache;
 
     void optimize();
-
-    /**
-      Given a list of light sources in the scene, the function decides which scene node should be lit by which
-      light and applies this decision to the lights and scene, adds a defaults light if there is none etc.
-     */
-
-    void setUpLights(std::vector<osg::ref_ptr<osg::LightSource>> *lightNodes);
 
     osg::ref_ptr<osg::Drawable> mSelected;           ///< debug selection
     osg::ref_ptr<osg::Material> mHighlightMaterial;  ///< for highlighting debug selection

--- a/components/renderer/osg_renderer.hpp
+++ b/components/renderer/osg_renderer.hpp
@@ -67,14 +67,14 @@ public:
 
     void setUpLights(std::vector<osg::ref_ptr<osg::LightSource>> *lightNodes);
 
+    void optimize();
+
 protected:
     osg::ref_ptr<osgViewer::Viewer> mViewer;    
     osg::ref_ptr<osg::Group> mRootNode;            ///< root node of the whole scene being rendered
     osg::ref_ptr<ImGuiHandler> mImGuiHandler;
     MFFile::FileSystem *mFileSystem;
     OSGCache mLoaderCache;
-
-    void optimize();
 
     osg::ref_ptr<osg::Drawable> mSelected;           ///< debug selection
     osg::ref_ptr<osg::Material> mHighlightMaterial;  ///< for highlighting debug selection

--- a/components/scene2_bin/osg_scene2bin.cpp
+++ b/components/scene2_bin/osg_scene2bin.cpp
@@ -198,7 +198,7 @@ osg::ref_ptr<osg::Node> OSGStaticSceneLoader::load(MFFormat::DataFormatScene2BIN
             objectTransform->addChild(objectNode);
             objectTransform->getOrCreateUserDataContainer()->addDescription("scene2.bin model"); // mark the node as a model loaded from scene2.bin
             objectTransform->setName(object.mParentName);    // hack: store the parent name in node name
-            nodeMap->insert(nodeMap->begin(),std::pair<std::string,osg::ref_ptr<osg::Group>>(object.mName,objectTransform));
+            nodeMap->insert(nodeMap->begin(),std::make_pair(object.mName,objectTransform));
             loadedNodes.push_back(objectTransform.get());
             loadedNames.push_back(object.mName);
         }

--- a/components/scene2_bin/osg_scene2bin.hpp
+++ b/components/scene2_bin/osg_scene2bin.hpp
@@ -33,7 +33,7 @@ public:
     typedef std::vector<osg::ref_ptr<osg::LightSource>> LightList;
 
     OSGScene2BinLoader();
-    osg::ref_ptr<osg::Node> load(std::ifstream &srcFile, std::string fileName="");
+    osg::ref_ptr<osg::Node> load(MFFormat::DataFormatScene2BIN *format, std::string fileName="");
     LightList getLightNodes()            { return mLightNodes;           };
     osg::Group *getCameraRelativeGroup() { return mCameraRelative.get(); };
     float getViewDistance()              { return mViewDistance;         };

--- a/components/scene2_bin/osg_scene2bin.hpp
+++ b/components/scene2_bin/osg_scene2bin.hpp
@@ -27,12 +27,12 @@
 namespace MFFormat
 {
 
-class OSGScene2BinLoader : public OSGLoader
+class OSGStaticSceneLoader : public OSGLoader
 {
 public:
     typedef std::vector<osg::ref_ptr<osg::LightSource>> LightList;
 
-    OSGScene2BinLoader();
+    OSGStaticSceneLoader();
     osg::ref_ptr<osg::Node> load(MFFormat::DataFormatScene2BIN *format, std::string fileName="");
     LightList getLightNodes()            { return mLightNodes;           };
     osg::Group *getCameraRelativeGroup() { return mCameraRelative.get(); };

--- a/components/scene2_bin/parser_scene2bin.hpp
+++ b/components/scene2_bin/parser_scene2bin.hpp
@@ -64,6 +64,8 @@ public:
     typedef enum {
         SPECIAL_OBJECT_TYPE_NONE = 0,
         SPECIAL_OBJECT_TYPE_PHYSICAL = 0x23,
+        SPECIAL_OBJECT_TYPE_PLAYER = 0x02,
+        SPECIAL_OBJECT_TYPE_CHARACTER = 0x1B,
     } SpecialObjectType;
 
     typedef enum {

--- a/components/scene2_bin/parser_scene2bin.hpp
+++ b/components/scene2_bin/parser_scene2bin.hpp
@@ -66,6 +66,9 @@ public:
         SPECIAL_OBJECT_TYPE_PHYSICAL = 0x23,
         SPECIAL_OBJECT_TYPE_PLAYER = 0x02,
         SPECIAL_OBJECT_TYPE_CHARACTER = 0x1B,
+        SPECIAL_OBJECT_TYPE_CAR = 0x06,
+        SPECIAL_OBJECT_TYPE_PUB_VEHICLE = 0x08,
+        SPECIAL_OBJECT_TYPE_SCRIPT = 0x05,
     } SpecialObjectType;
 
     typedef enum {

--- a/components/spatial_entity/factory.cpp
+++ b/components/spatial_entity/factory.cpp
@@ -156,7 +156,7 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createPropEntity(MFFormat::DataF
 
     mRenderer->getRootNode()->addChild(visualTransform);
 
-    return createEntity(visualTransform.get(), body, motionState, "dynamic " + object->mName, SpatialEntity::RIGID);
+    return createEntity(visualTransform.get(), body, motionState, object->mName, SpatialEntity::RIGID);
 }
 
 MFGame::SpatialEntity::Id SpatialEntityFactory::createPropEntity(std::string modelName, btScalar mass)
@@ -188,7 +188,7 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createPropEntity(std::string mod
 
     mRenderer->getRootNode()->addChild(visualTransform);
 
-    return createEntity(visualTransform.get(), body, motionState, "dynamic (undefined)", SpatialEntity::RIGID);
+    return createEntity(visualTransform.get(), body, motionState, "(undefined)", SpatialEntity::RIGID);
 }
 
 osg::ref_ptr<osg::Node> ObjectFactory::loadModel(std::string modelName)

--- a/components/spatial_entity/factory.cpp
+++ b/components/spatial_entity/factory.cpp
@@ -40,18 +40,22 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createPawnEntity(std::string mod
 {
     MFUtil::FullRigidBody body;
 
-    body.mMotionState = std::make_shared<btDefaultMotionState>(
-        btTransform(btQuaternion(0, 0, 0, mass),
-        btVector3(0, 0, 0)));
+    btTransform transform;
+    transform.setIdentity();
 
-    btVector3 inertia;
-    mPhysicalCapsuleShape->calculateLocalInertia(mass,inertia);
+    body.mMotionState = std::make_shared<btDefaultMotionState>(transform);
+
+    btVector3 inertia(0,0,0);
+
+    if (mass)
+        mPhysicalCapsuleShape->calculateLocalInertia(mass,inertia);
+
     body.mBody = std::make_shared<btRigidBody>(mass, body.mMotionState.get(), mPhysicalCapsuleShape.get(), inertia);
     
-    if (mass)
+    if (mass) {
         body.mBody->setActivationState(DISABLE_DEACTIVATION);
-
-    body.mBody->setFriction(0);
+        body.mBody->setFriction(0);
+    }
     mPhysicsWorld->getWorld()->addRigidBody(body.mBody.get());
 
     osg::ref_ptr<osg::MatrixTransform> visualTransform = new osg::MatrixTransform();

--- a/components/spatial_entity/factory.cpp
+++ b/components/spatial_entity/factory.cpp
@@ -120,7 +120,7 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createTestShapeEntity(btCollisio
     return createEntity(visualTransform.get(),physicalBody,motionState,"test");
 }
 
-MFGame::SpatialEntity::Id SpatialEntityFactory::createDynamicEntity(MFFormat::DataFormatScene2BIN::Object * object)
+MFGame::SpatialEntity::Id SpatialEntityFactory::createPropEntity(MFFormat::DataFormatScene2BIN::Object * object)
 {
     btScalar mass = object->mSpecialProps.mWeight;
     btTransform transform;
@@ -135,7 +135,6 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createDynamicEntity(MFFormat::Da
     shape->setMargin(0.05f);
     shape->calculateLocalInertia(mass, inertia);
     auto body = std::make_shared<btRigidBody>(mass, motionState.get(), shape, inertia);
-    body->setActivationState(DISABLE_DEACTIVATION);
     mPhysicsWorld->getWorld()->addRigidBody(body.get());
     
     osg::ref_ptr<osg::MatrixTransform> visualTransform = new osg::MatrixTransform();

--- a/components/spatial_entity/factory.cpp
+++ b/components/spatial_entity/factory.cpp
@@ -120,6 +120,45 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createTestShapeEntity(btCollisio
     return createEntity(visualTransform.get(),physicalBody,motionState,"test");
 }
 
+MFGame::SpatialEntity::Id SpatialEntityFactory::createDynamicEntity(MFFormat::DataFormatScene2BIN::Object * object)
+{
+    /*MFUtil::FullRigidBody body;
+
+    btScalar mass = object->mSpecialProps.mWeight;
+    body.mMotionState = std::make_shared<btDefaultMotionState>(
+        btTransform(btQuaternion(0, 0, 0, mass),
+            btVector3(0, 0, 0)));
+
+    btVector3 inertia;
+    mTestPhysicalSphereShape->calculateLocalInertia(mass, inertia);
+    body.mBody = std::make_shared<btRigidBody>(mass, body.mMotionState.get(), mTestPhysicalSphereShape.get(), inertia);
+    body.mBody->setActivationState(DISABLE_DEACTIVATION);
+    body.mBody->setFriction(0);
+    mPhysicsWorld->getWorld()->addRigidBody(body.mBody.get());*/
+
+    osg::ref_ptr<osg::MatrixTransform> visualTransform = new osg::MatrixTransform();
+
+    if (object->mModelName.length() == 0)
+    {
+        visualTransform->addChild(mTestBoxNode.get());
+    }
+    else
+    {
+        auto cache = mRenderer->getLoaderCache();
+        auto node = (osg::Node *)cache->getObject(object->mModelName).get();
+
+        if (!node) {
+            node = loadModel(object->mModelName);
+        }
+
+        visualTransform->addChild(node);
+    }
+
+    mRenderer->getRootNode()->addChild(visualTransform);
+
+    return createEntity(visualTransform.get(), nullptr, nullptr, "dynamic " + object->mName, SpatialEntity::RIGID);
+}
+
 osg::ref_ptr<osg::Node> ObjectFactory::loadModel(std::string modelName)
 {
     osg::ref_ptr<osg::Node> node = nullptr;
@@ -137,29 +176,23 @@ osg::ref_ptr<osg::Node> ObjectFactory::loadModel(std::string modelName)
 MFFormat::DataFormat4DS * ObjectFactory::loadModelData(std::string modelName)
 {
     MFFormat::DataFormat4DS *model = nullptr;
-    if (mModelCache) {
-        model = mModelCache->getObject(modelName);
+    
+    model = mModelCache.getObject(modelName);
 
-    loadModel:
-        if (!model) {
-            model = new MFFormat::DataFormat4DS();
-            std::ifstream file4DS;
-            if (!mFileSystem->open(file4DS, "models/" + modelName)) {
-                MFLogger::Logger::warn("Couldn't not open 4ds file: " + modelName + ".", SPATIAL_ENTITY_FACTORY_MODULE_STR);
-            }
-            else {
-                model->load(file4DS);
-                file4DS.close();
-            }
-
-            if (mModelCache)
-                mModelCache->storeObject(modelName, model);
+    if (!model) {
+        model = new MFFormat::DataFormat4DS();
+        std::ifstream file4DS;
+        if (!mFileSystem->open(file4DS, "models/" + modelName)) {
+            MFLogger::Logger::warn("Couldn't not open 4ds file: " + modelName + ".", SPATIAL_ENTITY_FACTORY_MODULE_STR);
         }
-    }
-    else {
-        goto loadModel;
-    }
+        else {
+            model->load(file4DS);
+            file4DS.close();
+        }
 
+        mModelCache.storeObject(modelName, model);
+    }
+    
     return model;
 }
 
@@ -173,129 +206,8 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createTestBoxEntity()
     return createTestShapeEntity(mTestPhysicalBoxShape.get(),mTestBoxNode.get());
 }
 
-class CreateEntitiesFromSceneVisitor: public osg::NodeVisitor
-{
-public:
-    CreateEntitiesFromSceneVisitor(std::vector<MFUtil::NamedRigidBody> *treeKlzBodies, MFGame::SpatialEntityFactory *entityFactory): osg::NodeVisitor()
-    {
-        mTreeKlzBodies = treeKlzBodies;
-        mEntityFactory = entityFactory;
-        mModelName = "";
-
-        for (int i = 0; i < (int) treeKlzBodies->size(); ++i)
-        {
-            std::string name = (*treeKlzBodies)[i].mName;
-            mNameToBody.insert(std::pair<std::string,MFUtil::NamedRigidBody *>(name,&((*treeKlzBodies)[i])));
-        }
-    }
-
-    virtual void apply(osg::Node &n) override
-    {
-        MFUtil::traverse(this,n);
-    }
-
-    virtual void apply(osg::MatrixTransform &n) override
-    {
-        std::string modelName = "";
-
-        if (n.getUserDataContainer())
-        {
-            std::vector<std::string> descriptions = n.getUserDataContainer()->getDescriptions();
-
-            if (descriptions.size() > 0)
-            {
-                if (descriptions[0].compare("scene2.bin model") == 0)
-                {
-                    modelName = n.getName();
-                }
-                else if (descriptions[0].compare("4ds mesh") == 0)
-                {
-                    std::vector<MFUtil::NamedRigidBody *> matches = findCollisions(n.getName());
-                    std::string fullName = mModelName.length() > 0 ? mModelName + "." + n.getName() : n.getName();
-
-                    if (matches.size() == 0)
-                    {
-                        MFLogger::Logger::warn("Could not find matching collision for visual node \"" + n.getName() + "\" (model: \"" + mModelName + "\").",SPATIAL_ENTITY_FACTORY_MODULE_STR);
-                        mEntityFactory->createEntity(&n,0,0,fullName);
-                    }
-                    else
-                    {
-                        for (int i = 0; i < (int) matches.size(); ++i)
-                        {
-                            mEntityFactory->createEntity(&n, matches[i]->mRigidBody.mBody,matches[i]->mRigidBody.mMotionState,fullName);
-                            mMatchedBodies.insert(matches[i]->mName);
-                        }
-                    }
-                }
-            }
-        }
-
-        if (modelName.size() > 0)
-            mModelName = modelName;          // traverse downwards with given name prefix
-
-        MFUtil::traverse(this,n);
-
-        if (modelName.size() > 0)
-            mModelName = "";                 // going back up => clear the name prefix
-    }
-
-    std::set<std::string> mMatchedBodies;
-
-protected:
-    std::vector<MFUtil::NamedRigidBody> *mTreeKlzBodies;
-    MFGame::SpatialEntityFactory *mEntityFactory;
-    std::string mModelName;                  // when traversing into a model loaded from scene2.bin, this will contain the model name (needed as the name prefix)
-    std::multimap<std::string,MFUtil::NamedRigidBody *> mNameToBody;
-
-    std::vector<MFUtil::NamedRigidBody *> findCollisions(std::string visualName)
-    {
-        std::vector<MFUtil::NamedRigidBody *> result;
-
-        auto found = mNameToBody.equal_range(visualName);
-
-        for (auto it = found.first; it != found.second; ++it)
-            result.push_back(it->second);
-
-        found = mNameToBody.equal_range(mModelName);
-
-        for (auto it = found.first; it != found.second; ++it)
-            result.push_back(it->second);
-
-        found = mNameToBody.equal_range(mModelName + "." + visualName);
-
-        for (auto it = found.first; it != found.second; ++it)
-            result.push_back(it->second);
-
-        return result;
-    }
-};
-
-void SpatialEntityFactory::createMissionEntities()
-{
-    auto treeKlzBodies = mPhysicsWorld->getTreeKlzBodies();
-
-    CreateEntitiesFromSceneVisitor v(&treeKlzBodies,this);
-    mRenderer->getRootNode()->accept(v);
-
-    // process the unmatched rigid bodies:
-
-    for (int i = 0; i < (int) treeKlzBodies.size(); ++i)
-    {
-        if (v.mMatchedBodies.find(treeKlzBodies[i].mName) != v.mMatchedBodies.end())
-            continue;
-
-        createEntity(0,
-            treeKlzBodies[i].mRigidBody.mBody,
-            treeKlzBodies[i].mRigidBody.mMotionState,
-            treeKlzBodies[i].mName);
-    }
-
-    // TODO: set the static flag to the loaded bodies here
-}
-
 ObjectFactory::ObjectFactory(MFRender::OSGRenderer *renderer, MFPhysics::BulletPhysicsWorld *physicsWorld)
 {
-    mModelCache = nullptr;
     mDebugMode = false;
 
     mFileSystem = MFFile::FileSystem::getInstance();

--- a/components/spatial_entity/factory.cpp
+++ b/components/spatial_entity/factory.cpp
@@ -105,7 +105,9 @@ MFGame::SpatialEntity::Id SpatialEntityFactory::createPawnEntity(std::string mod
                 MFLogger::Logger::warn("Couldn't not open 4ds file: " + modelName + ".", SPATIAL_ENTITY_FACTORY_MODULE_STR);
             }
             else {
-                model = l4ds.load(file4DS, modelName);
+                MFFormat::DataFormat4DS l4dsParser;
+                l4dsParser.load(file4DS);
+                model = l4ds.load(&l4dsParser, modelName);
                 file4DS.close();
                 model->setName(modelName);
             }

--- a/components/spatial_entity/factory.hpp
+++ b/components/spatial_entity/factory.hpp
@@ -13,17 +13,22 @@
 namespace MFGame
 {
 
+    typedef MFFormat::LoaderCache<MFFormat::DataFormat4DS*> ModelCache;
+    typedef MFFormat::LoaderCache<btTriangleMesh*> FaceColsCache;
+
 class ObjectFactory {
 public:
     ObjectFactory(MFRender::OSGRenderer *renderer, MFPhysics::BulletPhysicsWorld *physicsWorld);
     
     osg::ref_ptr<osg::Node> loadModel(std::string modelName);
     MFFormat::DataFormat4DS *loadModelData(std::string modelName);
+    btTriangleMesh *loadFaceCols(std::string modelName, int meshId=0);
     
     void setDebugMode(bool enable) { mDebugMode = enable; };
 
 protected:
-    MFFormat::ModelCache mModelCache;
+    ModelCache mModelCache;
+    FaceColsCache mFaceColsCache;
     MFPhysics::BulletPhysicsWorld *mPhysicsWorld;
     MFFile::FileSystem *mFileSystem;
     MFRender::OSGRenderer *mRenderer;

--- a/components/spatial_entity/factory.hpp
+++ b/components/spatial_entity/factory.hpp
@@ -70,7 +70,7 @@ public:
     MFGame::SpatialEntity::Id createPawnEntity(std::string modelName="");
     MFGame::SpatialEntity::Id createCameraEntity();
     MFGame::SpatialEntity::Id createTestShapeEntity(btCollisionShape *colShape, osg::ShapeDrawable *visualNode);
-    MFGame::SpatialEntity::Id createDynamicEntity(MFFormat::DataFormatScene2BIN::Object *object);
+    MFGame::SpatialEntity::Id createPropEntity(MFFormat::DataFormatScene2BIN::Object *object);
 
 protected: 
     MFGame::SpatialEntityManager *mEntityManager;

--- a/components/spatial_entity/factory.hpp
+++ b/components/spatial_entity/factory.hpp
@@ -13,28 +13,18 @@
 namespace MFGame
 {
 
-class SpatialEntityFactory
-{
+class ObjectFactory {
 public:
-    SpatialEntityFactory(MFRender::OSGRenderer *renderer, MFPhysics::BulletPhysicsWorld *physicsWorld, MFGame::SpatialEntityManager *entityManager);
-    void createMissionEntities();
-    void setDebugMode(bool enable)    { mDebugMode = enable; };
+    ObjectFactory(MFRender::OSGRenderer *renderer, MFPhysics::BulletPhysicsWorld *physicsWorld);
+    void setModelCache(MFFormat::ModelCache *modelCache) { mModelCache = modelCache; }
 
-    MFGame::SpatialEntity::Id createEntity(
-        osg::MatrixTransform *graphicNode,
-        std::shared_ptr<btRigidBody> physicsBody=0,
-        std::shared_ptr<btDefaultMotionState> physicsMotionsState=0, 
-        std::string name="",
-        SpatialEntity::PhysicsBehavior physicsBehavior=SpatialEntity::RIGID);
+    osg::ref_ptr<osg::Node> loadModel(std::string modelName);
+    MFFormat::DataFormat4DS *loadModelData(std::string modelName);
+    
+    void setDebugMode(bool enable) { mDebugMode = enable; };
 
-    MFGame::SpatialEntity::Id createTestBallEntity();
-    MFGame::SpatialEntity::Id createTestBoxEntity();
-    MFGame::SpatialEntity::Id createPawnEntity(std::string modelName="");
-    MFGame::SpatialEntity::Id createCameraEntity();
-    MFGame::SpatialEntity::Id createTestShapeEntity(btCollisionShape *colShape, osg::ShapeDrawable *visualNode);
-
-protected: 
-    MFGame::SpatialEntityManager *mEntityManager;
+protected:
+    MFFormat::ModelCache *mModelCache;
     MFPhysics::BulletPhysicsWorld *mPhysicsWorld;
     MFFile::FileSystem *mFileSystem;
     MFRender::OSGRenderer *mRenderer;
@@ -57,6 +47,29 @@ protected:
     std::shared_ptr<btCollisionShape> mCameraShape;
 
     bool mDebugMode;
+};
+
+class SpatialEntityFactory : public ObjectFactory
+{
+public:
+    SpatialEntityFactory(MFRender::OSGRenderer *renderer, MFPhysics::BulletPhysicsWorld *physicsWorld, MFGame::SpatialEntityManager *entityManager);
+    void createMissionEntities();
+
+    MFGame::SpatialEntity::Id createEntity(
+        osg::MatrixTransform *graphicNode,
+        std::shared_ptr<btRigidBody> physicsBody=0,
+        std::shared_ptr<btDefaultMotionState> physicsMotionsState=0, 
+        std::string name="",
+        SpatialEntity::PhysicsBehavior physicsBehavior=SpatialEntity::RIGID);
+
+    MFGame::SpatialEntity::Id createTestBallEntity();
+    MFGame::SpatialEntity::Id createTestBoxEntity();
+    MFGame::SpatialEntity::Id createPawnEntity(std::string modelName="");
+    MFGame::SpatialEntity::Id createCameraEntity();
+    MFGame::SpatialEntity::Id createTestShapeEntity(btCollisionShape *colShape, osg::ShapeDrawable *visualNode);
+
+protected: 
+    MFGame::SpatialEntityManager *mEntityManager;
 };
 
 }

--- a/components/spatial_entity/factory.hpp
+++ b/components/spatial_entity/factory.hpp
@@ -67,10 +67,11 @@ public:
 
     MFGame::SpatialEntity::Id createTestBallEntity();
     MFGame::SpatialEntity::Id createTestBoxEntity();
-    MFGame::SpatialEntity::Id createPawnEntity(std::string modelName="");
+    MFGame::SpatialEntity::Id createPawnEntity(std::string modelName="", btScalar mass=150.0f);
     MFGame::SpatialEntity::Id createCameraEntity();
     MFGame::SpatialEntity::Id createTestShapeEntity(btCollisionShape *colShape, osg::ShapeDrawable *visualNode);
     MFGame::SpatialEntity::Id createPropEntity(MFFormat::DataFormatScene2BIN::Object *object);
+    MFGame::SpatialEntity::Id createPropEntity(std::string modelName, btScalar mass=20.0f);
 
 protected: 
     MFGame::SpatialEntityManager *mEntityManager;

--- a/components/spatial_entity/factory.hpp
+++ b/components/spatial_entity/factory.hpp
@@ -16,15 +16,14 @@ namespace MFGame
 class ObjectFactory {
 public:
     ObjectFactory(MFRender::OSGRenderer *renderer, MFPhysics::BulletPhysicsWorld *physicsWorld);
-    void setModelCache(MFFormat::ModelCache *modelCache) { mModelCache = modelCache; }
-
+    
     osg::ref_ptr<osg::Node> loadModel(std::string modelName);
     MFFormat::DataFormat4DS *loadModelData(std::string modelName);
     
     void setDebugMode(bool enable) { mDebugMode = enable; };
 
 protected:
-    MFFormat::ModelCache *mModelCache;
+    MFFormat::ModelCache mModelCache;
     MFPhysics::BulletPhysicsWorld *mPhysicsWorld;
     MFFile::FileSystem *mFileSystem;
     MFRender::OSGRenderer *mRenderer;
@@ -53,7 +52,6 @@ class SpatialEntityFactory : public ObjectFactory
 {
 public:
     SpatialEntityFactory(MFRender::OSGRenderer *renderer, MFPhysics::BulletPhysicsWorld *physicsWorld, MFGame::SpatialEntityManager *entityManager);
-    void createMissionEntities();
 
     MFGame::SpatialEntity::Id createEntity(
         osg::MatrixTransform *graphicNode,
@@ -67,6 +65,7 @@ public:
     MFGame::SpatialEntity::Id createPawnEntity(std::string modelName="");
     MFGame::SpatialEntity::Id createCameraEntity();
     MFGame::SpatialEntity::Id createTestShapeEntity(btCollisionShape *colShape, osg::ShapeDrawable *visualNode);
+    MFGame::SpatialEntity::Id createDynamicEntity(MFFormat::DataFormatScene2BIN::Object *object);
 
 protected: 
     MFGame::SpatialEntityManager *mEntityManager;

--- a/components/spatial_entity/manager.cpp
+++ b/components/spatial_entity/manager.cpp
@@ -19,6 +19,26 @@ SpatialEntity *SpatialEntityManager::getEntityById(MFGame::SpatialEntity::Id id)
     return entity.get();
 }
 
+SpatialEntity *SpatialEntityManager::getEntityByName(std::string name)
+{
+    std::shared_ptr<SpatialEntity> entity = nullptr;
+
+    for (auto const pair : mEntities) {
+        if (pair.second && !pair.second->getName().compare(name)) {
+            entity = pair.second;
+            break;
+        }
+    }
+
+    if (!entity.get())
+    {
+        MFLogger::Logger::warn("Can't retrieve invalid entity.", SPATIAL_ENTITY_MANAGER_MODULE_STR);
+        return nullptr;
+    }
+
+    return entity.get();
+}
+
 bool SpatialEntityManager::isValid(MFGame::SpatialEntity::Id ident)
 {
     auto entity = mEntities[ident];

--- a/components/spatial_entity/manager.cpp
+++ b/components/spatial_entity/manager.cpp
@@ -3,17 +3,6 @@
 namespace MFGame
 {
 
-SpatialEntity *SpatialEntityManager::getEntityByIndex(unsigned int index)
-{
-    if (index < 0 || index > mEntities.size())
-    {
-        return nullptr;
-    }
-
-    // TODO return entity by index
-    return nullptr;
-}
-
 SpatialEntity *SpatialEntityManager::getEntityById(MFGame::SpatialEntity::Id id)
 {
     if (id == MFGame::SpatialEntity::NullId)
@@ -61,7 +50,6 @@ void SpatialEntityManager::removeEntity(MFGame::SpatialEntity::Id ident)
         MFLogger::Logger::warn("Can't remove invalid entity.", SPATIAL_ENTITY_MANAGER_MODULE_STR);
         return;
     }
-    mEntities[ident].reset();
     mEntities.erase(ident);
     mNumEntities--;
 }

--- a/components/spatial_entity/manager.hpp
+++ b/components/spatial_entity/manager.hpp
@@ -18,13 +18,6 @@ public:
     SpatialEntityManager() {};
     SpatialEntity *getEntityById(MFGame::SpatialEntity::Id id);
 
-    /**
-     * \brief Returns valid entity by a raw index,
-     * if entity is invalid (e.g. removed) or index points outside the bounds of the pool
-     * it returns nullptr.
-     */
-    SpatialEntity *getEntityByIndex(unsigned int index);
-
     MFGame::SpatialEntity::Id addEntity(std::shared_ptr<SpatialEntity> entity);
     void removeEntity(MFGame::SpatialEntity::Id ident);
     bool isValid(MFGame::SpatialEntity::Id ident);
@@ -43,6 +36,8 @@ public:
      * \brief Returns the number of entity slots
      **/
     unsigned int getNumEntitySlots();
+
+    EntityMap *getEntities() { return &mEntities; };
 
 protected:
     EntityMap mEntities;

--- a/components/spatial_entity/manager.hpp
+++ b/components/spatial_entity/manager.hpp
@@ -18,6 +18,13 @@ public:
     SpatialEntityManager() {};
     SpatialEntity *getEntityById(MFGame::SpatialEntity::Id id);
 
+    /**
+     * Retrieves entity by its name.
+     * Note that there might be multiple entities with the same name and this method
+     * retrieves only the first one found. This makes the use case much more restricted.
+     */
+    SpatialEntity *getEntityByName(std::string name);
+
     MFGame::SpatialEntity::Id addEntity(std::shared_ptr<SpatialEntity> entity);
     void removeEntity(MFGame::SpatialEntity::Id ident);
     bool isValid(MFGame::SpatialEntity::Id ident);

--- a/components/spatial_entity/spatial_entity_impl.cpp
+++ b/components/spatial_entity/spatial_entity_impl.cpp
@@ -354,6 +354,7 @@ void SpatialEntityImpl::makePhysicsDebugOSGNode()        ///< Creates a visual r
             break;
         }
 
+        case BroadphaseNativeTypes::CONVEX_SHAPE_PROXYTYPE:
         case BroadphaseNativeTypes::TRIANGLE_MESH_SHAPE_PROXYTYPE:
         {
             auto *mesh =


### PR DESCRIPTION
Refactors the whole mission loading pipeline to make it possible for us to handle special object cases or just to simply make the code less confusing.

It also caches 4DS data into memory and makes sure we load runtime objects efficiently.